### PR TITLE
perf-test: disable testing options.

### DIFF
--- a/perf-test/app/page.tsx
+++ b/perf-test/app/page.tsx
@@ -113,9 +113,9 @@ const countOptions = [
   { id: 1, name: 20 },
   { id: 2, name: 50 },
   { id: 3, name: 100 },
-  { id: 4, name: 200 },
-  { id: 5, name: 500 },
-  { id: 6, name: 1000 },
+  //{ id: 4, name: 200 },
+  //{ id: 5, name: 500 },
+  //{ id: 6, name: 1000 },
 ];
 
 const playerOptions = [


### PR DESCRIPTION
these numbers are too harsh for testing now,
we must apply this after applying the deferred loading.