### PR TITLE
perf-test: adjust the dotLottie rendering quality.

### DIFF
--- a/perf-test/app/page.tsx
+++ b/perf-test/app/page.tsx
@@ -438,6 +438,7 @@ export default function Home() {
                     style={{width: size.width, height: size.height}}
                     loop 
                     autoplay
+                    renderConfig={{devicePixelRatio: 1}}
                   />
                 )
               }


### PR DESCRIPTION
The dotLottie player adjusts the resolution based on the device pixel ratio. We can forcibly set it to 1 to align the test environment with other players.