### PR TITLE
lottie: Fix render bug in DPR process

### DIFF
--- a/src/lottie-player.ts
+++ b/src/lottie-player.ts
@@ -186,7 +186,7 @@ export class LottiePlayer extends LitElement {
   * @since 1.0
   */
   @property({ type: Object })
-  readonly renderConfig?: RenderConfig;
+  public renderConfig?: RenderConfig;
 
   /**
    * Animation speed.
@@ -397,7 +397,7 @@ export class LottiePlayer extends LitElement {
   }
 
   private _render(): void {
-    if (this.renderConfig?.enableDevicePixelRatio) {
+    if (this.renderConfig?.enableDevicePixelRatio && this.currentState === PlayerState.Playing) {
       const dpr = window.devicePixelRatio;
       const { width, height } = this._canvas!.getBoundingClientRect();
       this._canvas!.width = width * dpr;


### PR DESCRIPTION
From 0.14.0, resize() method should not be double-called when initializing.

Corrected DPR option to process only when player is prepared.