### PR TITLE
lottie: Fix `getVersion` returns empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "types": "./dist/lottie-player.d.ts",
   "scripts": {
-    "build": "npm run clean && npm run copy:wasm && THORVG_VERSION=$(sed -n -e 4p ../meson.build | sed 's/..$//' | sed -r 's/.{19}//') rollup -c --bundleConfigAsCjs && rm -rf ./dist/thorvg-wasm.js",
+    "build": "npm run clean && npm run copy:wasm && THORVG_VERSION=$(sed -n -e 4p ./thorvg/meson.build | sed 's/..$//' | sed -r 's/.{19}//') rollup -c --bundleConfigAsCjs && rm -rf ./dist/thorvg-wasm.js",
     "build:watch": "npm run clean && npm run copy:wasm && rollup -c --bundleConfigAsCjs --watch",
     "copy:wasm": "cp ./thorvg/build_wasm/src/bindings/wasm/thorvg-wasm.js ./dist",
     "clean": "rm -rf dist && mkdir dist && touch dist/index.js",


### PR DESCRIPTION
getVersion() isn't working currently.

Corrected command on injecting the ThorVG version.