### PR TITLE
perf-test: enable only thorvg player.

### DIFF
--- a/perf-test/app/page.tsx
+++ b/perf-test/app/page.tsx
@@ -131,8 +131,8 @@ const countOptions = [
 
 const playerOptions = [
   { id: 1, name: 'thorvg-player' },
-  { id: 2, name: `dotlottie-web@${dotLottieReactPkg.dependencies["@lottiefiles/dotlottie-web"]}` },
-  { id: 3, name: `lottie-web@${reactLottiePlayerPkg.dependencies["lottie-web"]}` },
+  //{ id: 2, name: `dotlottie-web@${dotLottieReactPkg.dependencies["@lottiefiles/dotlottie-web"]}` },
+  //{ id: 3, name: `lottie-web@${reactLottiePlayerPkg.dependencies["lottie-web"]}` },
   //{ id: 4, name: 'skia/skottie' },
 ];
 


### PR DESCRIPTION
The dotLottie player has its own performance tests, ThorVG doesn't need to compare with other players anymore.

Please use other players only for internal testing purposes.