### PR TITLE
infra: reduce javascript bundle size

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,7 +18,11 @@ const globals = {
 export default [
   {
     input: "./src/lottie-player.ts",
-    treeshake: true,
+    treeshake: {
+      moduleSideEffects: false,
+      propertyReadSideEffects: false,
+      tryCatchDeoptimization: false
+    },
     output: [
       {
         file: './dist/lottie-player.js',
@@ -28,6 +32,7 @@ export default [
         inlineDynamicImports: true,
         sourcemap: true,
         globals,
+        hoistTransitiveImports: true,
       },
       {
         file: pkg.main,
@@ -70,7 +75,12 @@ export default [
       }),
       nodeResolve(),
       terser({
-        compress: true,
+        compress: {
+          pure_getters: true,
+          passes: 3,
+          drop_console: true,
+          drop_debugger: true
+        },
         mangle: true,
         output: {
           comments: false,


### PR DESCRIPTION
The size of the JavaScript bundle, as well as the glue code, has been slightly reduced.

- enhanced tree shaking
- update compress option

[Before]
![CleanShot 2024-12-03 at 02 41 36](https://github.com/user-attachments/assets/77590fa8-f7dd-4632-8142-c6ed63eac9c0)

[After]
![CleanShot 2024-12-03 at 02 41 16](https://github.com/user-attachments/assets/10fcfe50-f8f3-4044-81de-fd254071e412)

`lottie-player.js` bundle got `-1%` size reduction