### PR TITLE
wasm: Separate binary based on backend engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,8 @@
   ],
   "types": "./dist/lottie-player.d.ts",
   "scripts": {
-    "build": "npm run clean && npm run copy:wasm && npm run copy:js && THORVG_VERSION=$(sed -n -e 4p ./thorvg/meson.build | sed 's/..$//' | sed -r 's/.{19}//') rollup -c --bundleConfigAsCjs && rm -rf ./dist/thorvg-wasm.js",
-    "build:watch": "npm run clean && npm run copy:wasm && rollup -c --bundleConfigAsCjs --watch",
-    "copy:wasm": "cp ./thorvg/build_wasm/src/bindings/wasm/thorvg-wasm.wasm ./dist",
-    "copy:js": "cp ./thorvg/build_wasm/src/bindings/wasm/thorvg-wasm.js ./dist",
-    "clean": "rm -rf dist && mkdir dist && touch dist/index.js",
+    "build": "THORVG_VERSION=$(sed -n -e 4p ./thorvg/meson.build | sed 's/..$//' | sed -r 's/.{19}//') rollup -c --bundleConfigAsCjs",
+    "build:watch": "rollup -c --bundleConfigAsCjs --watch",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint ./src --ext .ts,.tsx,.js",
     "lint:fix": "eslint ./src --ext .ts,.tsx,.js --fix"

--- a/wasm_build.sh
+++ b/wasm_build.sh
@@ -1,0 +1,27 @@
+rm -rf dist
+mkdir dist
+cd thorvg
+
+# Build software backend
+rm -rf build_wasm
+./wasm_build.sh sw $1
+cp build_wasm/src/bindings/wasm/thorvg-wasm.wasm ../dist/thorvg-software-wasm.wasm
+cp build_wasm/src/bindings/wasm/thorvg-wasm.js ../dist/thorvg-software-wasm.js
+
+# Build webgpu backend
+rm -rf build_wasm
+./wasm_build.sh wg $1
+cp build_wasm/src/bindings/wasm/thorvg-wasm.wasm ../dist/thorvg-webgpu-wasm.wasm
+cp build_wasm/src/bindings/wasm/thorvg-wasm.js ../dist/thorvg-webgpu-wasm.js
+
+# Build webgl backend
+rm -rf build_wasm
+./wasm_build.sh gl $1
+cp build_wasm/src/bindings/wasm/thorvg-wasm.wasm ../dist/thorvg-webgl-wasm.wasm
+cp build_wasm/src/bindings/wasm/thorvg-wasm.js ../dist/thorvg-webgl-wasm.js
+
+# Post process
+cd ..
+yarn build
+
+ls -lrt ./dist


### PR DESCRIPTION
This approach reduces loading time and decreases the binary/bundle size, making it smaller and faster compared to a combined binary. Previously, 1149KB was uniformly required to run on software, WebGL, and WebGPU. Now, the total minimum size is 987KB, representing a 15% reduction.

**[Previous]**
- Total Bundle Size : 1149KB

**[Current]**
- Software : 987KB (-15%)
- WebGL : 1001KB (-13%)
- WebGPU : 1017KB (-12%)

![CleanShot 2024-12-18 at 14 05 25@2x](https://github.com/user-attachments/assets/135ee478-0de3-42a3-900e-ab41da6d7cc9)
