### PR TITLE
lottie: fix save2gif in GL/WG engine

### DIFF
--- a/src/lottie-player.ts
+++ b/src/lottie-player.ts
@@ -763,18 +763,18 @@ export class LottiePlayer extends LitElement {
    * @since 1.0
    */
   public async save2gif(src: string): Promise<void> {
-    if (!this._TVG) {
-      return;
-    }
-
+    const saver = new _module.TvgLottieAnimation(Renderer.SW, `#${this._canvas!.id}`);
     const bytes = await _parseSrc(src, FileType.JSON);
-    const isExported = this._TVG.save(bytes, 'gif');
+    const isExported = saver.save(bytes, 'gif');
     if (!isExported) {
-      throw new Error('Unable to save. Error: ', this._TVG.error());
+      const error = saver.error();
+      saver.delete();
+      throw new Error('Unable to save. Error: ', error);
     }
 
     const data = _module.FS.readFile('output.gif');
     if (data.length < 6) {
+      saver.delete();
       throw new Error(
         `Unable to save the GIF data. The generated file size is invalid.`
       );
@@ -782,6 +782,7 @@ export class LottiePlayer extends LitElement {
 
     const blob = new Blob([data], {type: 'application/octet-stream'});
     _downloadFile('output.gif', blob);
+    saver.delete();
   }
 
   /**


### PR DESCRIPTION
The saver works with the SW engine, but it fails to save as a GIF when the animation runs with GL/WG.

Use a new WASM instance to avoid this issue. This instance always saves the animation using the SW engine.

![CleanShot 2025-03-18 at 19 12 43](https://github.com/user-attachments/assets/2fea3703-2122-4e2e-a1bb-2c4ef1e30a94)


issue: https://github.com/thorvg/thorvg.viewer/issues/98