### PR TITLE
fix: correct build:watch script failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
   ],
   "types": "./dist/lottie-player.d.ts",
   "scripts": {
-    "build": "npm run clean && npm run copy:wasm && npm run copy:js && THORVG_VERSION=$(sed -n -e 4p ./thorvg/meson.build | sed 's/..$//' | sed -r 's/.{19}//') rollup -c --bundleConfigAsCjs && rm -rf ./dist/thorvg-wasm.js",
-    "build:watch": "npm run clean && npm run copy:wasm && rollup -c --bundleConfigAsCjs --watch",
+    "build": "npm run clean && npm run copy:wasm && npm run copy:js && THORVG_VERSION=$(npm run version --silent) rollup -c --bundleConfigAsCjs && rm -rf ./dist/thorvg-wasm.js",
+    "build:watch": "npm run clean && npm run copy:wasm && npm run copy:js && THORVG_VERSION=$(npm run version --silent) rollup -c --bundleConfigAsCjs --watch",
     "copy:wasm": "cp ./thorvg/build_wasm/src/bindings/wasm/thorvg-wasm.wasm ./dist",
     "copy:js": "cp ./thorvg/build_wasm/src/bindings/wasm/thorvg-wasm.js ./dist",
     "clean": "rm -rf dist && mkdir dist && touch dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint ./src --ext .ts,.tsx,.js",
-    "lint:fix": "eslint ./src --ext .ts,.tsx,.js --fix"
+    "lint:fix": "eslint ./src --ext .ts,.tsx,.js --fix",
+    "version": "sed -n -e 4p ./thorvg/meson.build | sed 's/..$//' | sed -r 's/.{19}//'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

I attempted to run local tests following the instructions from the [ThorVG Web Development guide](https://github.com/thorvg/thorvg/wiki/Web-Development#local-test-procedures).

During this process, I encountered and resolved two issues:

---

### 1. `yarn build:watch` failed

**Error:**

```
[!] RollupError: Could not resolve "../dist/thorvg-wasm" from "src/lottie-player.ts"
```

**Cause:**

In `lottie-player.ts`, the following import is used:

```ts
import Module from '../dist/thorvg-wasm';
```

However, the `build:watch` script does not copy `thorvg-wasm.js` into the `dist` directory, which leads to a failure when resolving the module.

**Solution:**

I added the `npm run copy:js` command to the `build:watch` script so that the required file is available in `dist`.

---

### 2. Example animations not working

After running `npx http-server .` and opening the examples in the browser, I encountered the following error:

```
v4.js:24 Uncaught (in promise) TypeError: ye.TvgLottieAnimation is not a constructor
```

**Suspected Cause:**

The example code uses the following URL to load the wasm file:

```ts
const _wasmUrl = 'https://unpkg.com/@thorvg/lottie-player@latest/dist/thorvg-wasm.wasm';
```

It appears that the wasm file served from the CDN may not be functioning correctly.  
I also tried downloading the file and setting `animation.wasmUrl` manually to the local path, but the issue remained.  
I'm not entirely sure about the root cause — I’d appreciate it if you could point out anything I might have missed.

~**Solution:**~

~I updated the example files (`index.html`, `webgl.html`, `webgpu.html`) to use the locally built wasm path explicitly:~

```ts
animation.wasmUrl = "../dist/thorvg-wasm.wasm";
```


**It seems this requires a different approach.** 



