### PR TITLE
wasm: apply TypeScript bindings and d.ts to lottie-player.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "npm run clean && npm run copy:wasm && npm run copy:js && THORVG_VERSION=$(sed -n -e 4p ./thorvg/meson.build | sed 's/..$//' | sed -r 's/.{19}//') rollup -c --bundleConfigAsCjs && rm -rf ./dist/thorvg-wasm.js",
     "build:watch": "npm run clean && npm run copy:wasm && rollup -c --bundleConfigAsCjs --watch",
     "copy:wasm": "cp ./thorvg/build_wasm/src/bindings/wasm/thorvg-wasm.wasm ./dist",
-    "copy:js": "cp ./thorvg/build_wasm/src/bindings/wasm/thorvg-wasm.js ./dist",
+    "copy:js": "cp ./thorvg/build_wasm/src/bindings/wasm/thorvg-wasm.{js,d.ts} ./dist",
     "clean": "rm -rf dist && mkdir dist && touch dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint ./src --ext .ts,.tsx,.js",

--- a/src/lottie-player.ts
+++ b/src/lottie-player.ts
@@ -26,13 +26,14 @@ import { v4 as uuidv4 } from 'uuid';
 
 // @ts-ignore: WASM Glue code doesn't have type & Only available on build progress
 import Module from '../dist/thorvg-wasm';
+import type { MainModule, TvgLottieAnimation } from '../dist/thorvg-wasm';
 import { THORVG_VERSION } from './version';
 
 type LottieJson = Map<PropertyKey, any>;
-type TvgModule = any;
+type TvgModule = TvgLottieAnimation;
 
 const _wasmUrl = 'https://unpkg.com/@thorvg/lottie-player@latest/dist/thorvg-wasm.wasm';
-let _module: any;
+let _module: MainModule | null;
 let _moduleRequested: boolean = false;
 
 // Define library version
@@ -191,7 +192,7 @@ const _initModule = async (engine: Renderer) => {
 
   _initStatus = InitStatus.REQUESTED;
   while (true) {
-    const res = _module.init();
+    const res = _module!.init();
     switch (res) {
       case 0:
         _initStatus = InitStatus.INITIALIZED;
@@ -397,7 +398,7 @@ export class LottiePlayer extends LitElement {
       height -= bottom - windowHeight;
     }
 
-    this._TVG.viewport(x, y, width, height);
+    this._TVG!.viewport(x, y, width, height);
   }
 
   private _observerCallback(entries: IntersectionObserverEntry[]) {
@@ -452,9 +453,9 @@ export class LottiePlayer extends LitElement {
   }
 
   private _loadBytes(data: Uint8Array, rPath: string = ''): void {
-    const isLoaded = this._TVG.load(data, this.fileType, this._canvas!.width, this._canvas!.height, rPath);
+    const isLoaded = this._TVG!.load(data, this.fileType, this._canvas!.width, this._canvas!.height, rPath);
     if (!isLoaded) {
-      throw new Error('Unable to load an image. Error: ', this._TVG.error());
+      throw new Error('Unable to load an image. Error: ' + this._TVG!.error());
     }
 
     this._render();
@@ -478,9 +479,9 @@ export class LottiePlayer extends LitElement {
       this._canvas!.height = height * dpr;
     }
 
-    this._TVG.resize(this._canvas!.width, this._canvas!.height);
+    this._TVG!.resize(this._canvas!.width, this._canvas!.height);
     this._viewport();
-    const isUpdated = this._TVG.update();
+    const isUpdated = this._TVG!.update();
 
     if (!isUpdated) {
       return;
@@ -488,11 +489,11 @@ export class LottiePlayer extends LitElement {
 
     // webgpu & webgl
     if (this.renderConfig?.renderer === Renderer.WG || this.renderConfig?.renderer === Renderer.GL) {
-      this._TVG.render();
+      this._TVG!.render();
       return;
     }
 
-    const buffer = this._TVG.render();
+    const buffer = this._TVG!.render();
     const clampedBuffer = new Uint8ClampedArray(buffer.buffer, buffer.byteOffset, buffer.byteLength);
     if (clampedBuffer.length < 1) {
       return;
@@ -507,7 +508,7 @@ export class LottiePlayer extends LitElement {
       return false;
     }
 
-    const duration = this._TVG.duration();
+    const duration = this._TVG!.duration();
     const currentTime = Date.now() / 1000;
     this.currentFrame = (currentTime - this._beginTime) / duration * this.totalFrame * this.speed;
     if (this.direction === -1) {
@@ -543,13 +544,13 @@ export class LottiePlayer extends LitElement {
         frame: this.currentFrame,
       },
     }));
-    return this._TVG.frame(this.currentFrame);
+    return this._TVG!.frame(this.currentFrame);
   }
 
   private _frame(curFrame: number): void {
     this.pause();
     this.currentFrame = curFrame;
-    this._TVG.frame(curFrame);
+    this._TVG!.frame(curFrame);
   }
 
   /**
@@ -581,7 +582,7 @@ export class LottiePlayer extends LitElement {
       return;
     }
 
-    this.totalFrame = this._TVG.totalFrame();
+    this.totalFrame = this._TVG!.totalFrame();
     if (this.totalFrame < 1) {
       return;
     }
@@ -667,7 +668,7 @@ export class LottiePlayer extends LitElement {
     }
 
     this._TVG.delete();
-    this._TVG = null;
+    this._TVG = undefined;
     this.currentState = PlayerState.Destroyed;
 
     if (this._observer) {
@@ -684,7 +685,7 @@ export class LottiePlayer extends LitElement {
    * @since 1.0
    */
   public term(): void {
-    _module.term();
+    _module!.term();
     _module = null;
   }
 
@@ -763,16 +764,16 @@ export class LottiePlayer extends LitElement {
    * @since 1.0
    */
   public async save2gif(src: string): Promise<void> {
-    const saver = new _module.TvgLottieAnimation(Renderer.SW, `#${this._canvas!.id}`);
+    const saver = new _module!.TvgLottieAnimation(Renderer.SW, `#${this._canvas!.id}`);
     const bytes = await _parseSrc(src, FileType.JSON);
     const isExported = saver.save(bytes, 'gif');
     if (!isExported) {
       const error = saver.error();
       saver.delete();
-      throw new Error('Unable to save. Error: ', error);
+      throw new Error('Unable to save. Error: ' + error);
     }
 
-    const data = _module.FS.readFile('output.gif');
+    const data = _module!.FS.readFile('output.gif');
     if (data.length < 6) {
       saver.delete();
       throw new Error(


### PR DESCRIPTION
This PR updates `lottie-player.ts` to adopt the new TypeScript bindings introduced in [`thorvg#3678`](https://github.com/thorvg/thorvg/pull/3678).

These updates are related to [`thorvg.web#16`](https://github.com/thorvg/thorvg.web/issues/16), which requests better TypeScript support for the WASM output.