### PR TITLE
lottie: replace uuid with custom unique id

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@swc/core": "^1.3.99",
-    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "eslint": "^8.0.1",
     "eslint-config-standard-with-typescript": "^40.0.0",
@@ -66,7 +65,6 @@
   },
   "dependencies": {
     "lit": "^3.1.0",
-    "url": "^0.11.3",
-    "uuid": "^10.0.0"
+    "url": "^0.11.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,6 @@ const name = 'lottie-player';
 const globals = {
   url: "url",
   lit: "lit",
-  uuid: "uuid",
   "lit/decorators.js": "lit/decorators.js",
 };
 

--- a/src/lottie-player.ts
+++ b/src/lottie-player.ts
@@ -22,7 +22,6 @@
 
 import { html, PropertyValueMap, LitElement, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { v4 as uuidv4 } from 'uuid';
 
 // @ts-ignore: WASM Glue code doesn't have type & Only available on build progress
 import Module from '../dist/thorvg-wasm';
@@ -205,6 +204,10 @@ const _initModule = async (engine: Renderer) => {
       default:
     }
   }
+}
+
+const _generateUID = () => {
+  return Date.now().toString(36) + Math.random().toString(36).substring(2);
 }
 
 @customElement('lottie-player')
@@ -418,7 +421,7 @@ export class LottiePlayer extends LitElement {
   protected firstUpdated(_changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
     this._canvas = this.querySelector('.thorvg') as HTMLCanvasElement;
     
-    this._canvas.id = `thorvg-${uuidv4().replaceAll('-', '').substring(0, 6)}`;
+    this._canvas.id = `thorvg-${_generateUID()}`;
     this._canvas.width = this._canvas.offsetWidth;
     this._canvas.height = this._canvas.offsetHeight;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -478,11 +478,6 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
   integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
 
-"@types/uuid@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
-  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
-
 "@typescript-eslint/eslint-plugin@^6.4.0":
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz#30830c1ca81fd5f3c2714e524c4303e0194f9cd3"
@@ -2415,11 +2410,6 @@ url@^0.11.3:
   dependencies:
     punycode "^1.4.1"
     qs "^6.12.3"
-
-uuid@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
-  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Changes
Removes the `uuid` dependency across the project and replaces its usage with native alternatives or other utilities. Additionally, it cleans up related dependencies and configurations in various files.

### Replacement of `uuid` usage:

*  Updated `src/lottie-player.ts` to generate unique canvas IDs using a combination of `Date.now()` and `Math.random()` instead of `uuidv4`. [[1]](diffhunk://#diff-b00e87ab882980bad91534c8414d03d8137fbb1e3ecc49cf77a9daf4e38eb5f1L25) [[2]](diffhunk://#diff-b00e87ab882980bad91534c8414d03d8137fbb1e3ecc49cf77a9daf4e38eb5f1L421-R420)


### Removal of `uuid` dependency:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L50): Removed the `uuid` package and its type definitions (`@types/uuid`) from both `dependencies` and `devDependencies`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L50) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L68-R67) [[3]](diffhunk://#diff-f084e1ad57f1e750dda5bd9177c78941e2b951b781a9fec039508d33fa3c2e2cL23-L30)
* [`rollup.config.js`](diffhunk://#diff-6814bf77564b4f1c92f5861e184e28fe217c080a047fefa8b73a728f755ec45cL14): Removed `uuid` from the `globals` configuration.

