### PR TITLE
docs: fix typo and align method parameters in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ player.addEventListener('load', () => {
 **Parameters**
 | Name | Type | Description
 | --- | --- | --- |
-| src | `number` | The frame number to move, shouldn't be less than 0 and greater than `totalFrame`
+| frame | `number` | The frame number to move, shouldn't be less than 0 and greater than `totalFrame`
 
 **Return Type** : `void`
 
@@ -338,7 +338,7 @@ player.addEventListener('load', () => {
 **Parameters**
 | Name | Type | Description
 | --- | --- | --- |
-| value | `ExportableType` | File type to export
+| target | `ExportableType` | File type to export
 
 **Return Type** : `void`
 


### PR DESCRIPTION
### Changes

Fixed typo in README.md
* `backgroud` > `background`
* `destory` > `destroy`

Aligned parameter names with method signatures
* `src` > `frame`
* `value` > `target`