### PR TITLE
lottie: remove unused parameter from _loadBytes function

### DIFF
--- a/src/base-lottie-player.ts
+++ b/src/base-lottie-player.ts
@@ -440,7 +440,7 @@ export class BaseLottiePlayer extends LitElement {
   }
 
   private _loadBytes(data: Uint8Array): void {
-    const isLoaded = this.TVG.load(data, this.fileType, this.canvas!.width, this.canvas!.height, '');
+    const isLoaded = this.TVG.load(data, this.fileType, this.canvas!.width, this.canvas!.height);
     if (!isLoaded) {
       throw new Error(`Unable to load an image. Error: ${this.TVG.error()}`);
     }


### PR DESCRIPTION
This patch removes an unused parameter from the _loadBytes() function in base-lottie-player.ts.

Previously, the load() method was called with an unnecessary empty string ('') as the last argument. Since the underlying load() function no longer accepts that parameter, this cleanup aligns the code with the current API definition.

related commit(thorvg): [https://github.com/thorvg/thorvg/commit/1e6353bad44b5260453bd6519c8ecc7fdddd3da3](https://github.com/thorvg/thorvg/commit/1e6353bad44b5260453bd6519c8ecc7fdddd3da3)