### PR TITLE
perf-test: check GPU feature compatibility

### DIFF
--- a/perf-test/app/page.tsx
+++ b/perf-test/app/page.tsx
@@ -130,13 +130,13 @@ const countOptions = [
   //{ id: 6, name: 1000 },
 ];
 
-const playerOptions = [
-  { id: 1, name: 'ThorVG(Software)' },
-  { id: 2, name: 'ThorVG(WebGPU)' },
-  //{ id: 3, name: `dotlottie-web@${dotLottieReactPkg.dependencies["@lottiefiles/dotlottie-web"]}` },
-  //{ id: 4, name: `lottie-web@${reactLottiePlayerPkg.dependencies["lottie-web"]}` },
-  //{ id: 5, name: 'skia/skottie' },
+const playerOptions = [ 
+  { id: 1, name: 'ThorVG(Software)' } 
 ];
+
+if (typeof navigator !== 'undefined' && navigator.gpu) { 
+  playerOptions.push({ id: 2, name: 'ThorVG(WebGPU)' }); 
+}
 
 function classNames(...classes: any) {
   return classes.filter(Boolean).join(' ')


### PR DESCRIPTION
Remove WebGPU option from option list if it is not available

## Changes
- Remove WebGPU option from option list if it is not available 

## Result 

**Chrome(140.0.7339.210)** 

<img width="994" height="787" alt="image" src="https://github.com/user-attachments/assets/23178d6a-669f-4e1f-8ab5-3f3326a0d180" />


**Safari(18.5)**
<img width="1382" height="909" alt="image" src="https://github.com/user-attachments/assets/f71b94a8-d9f9-461e-bba0-93a8213923bf" />



