### PR TITLE
lottie(chore): keep glue code and exclude from npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
   },
   "files": [
     "dist/",
-    "!dist/thorvg.d.ts"
+    "!dist/thorvg.d.ts",
+    "!dist/thorvg.js"
   ],
   "types": "./dist/lottie-player.d.ts",
   "scripts": {
-    "build": "npm run clean && sh ./wasm_setup.sh && THORVG_VERSION=$(npm run version --silent) rollup -c --bundleConfigAsCjs && npm run clean:post",
+    "build": "npm run clean && sh ./wasm_setup.sh && THORVG_VERSION=$(npm run version --silent) rollup -c --bundleConfigAsCjs",
     "build:watch": "npm run clean && sh ./wasm_setup.sh && THORVG_VERSION=$(npm run version --silent) rollup -c --bundleConfigAsCjs --watch",
     "clean": "rm -rf dist && mkdir dist && touch dist/index.js",
-    "clean:post": "find ./dist -name 'thorvg.js' -type f -delete",
     "test": "echo \"Error: no test specified\" && exit 1",
     "test:build": "./build-test.sh",
     "lint": "eslint ./src --ext .ts,.tsx,.js",


### PR DESCRIPTION
These build artifacts are required during development but redundant in the published package as their functionality is already bundled into lottie-player.js and its type definition. Exclude at distribution level rather than build level for better maintainability.