### PR TITLE
package: exclude glue(thorvg.js) from all preset subdirectories

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "files": [
     "dist/",
     "!dist/thorvg.d.ts",
-    "!dist/thorvg.js"
+    "!dist/**/thorvg.js"
   ],
   "types": "./dist/lottie-player.d.ts",
   "scripts": {


### PR DESCRIPTION
The `thorvg.js` files were configured to be excluded from the final bundle
via alias settings. However, the paths under preset module subdirectories
(sw/, gl/, sw-lite/, gl-lite/) were not specified in the package.json
`files` field exclusion list.