### PR TITLE
perf-test: align displaying size with the canvas size

### DIFF
--- a/perf-test/app/page.tsx
+++ b/perf-test/app/page.tsx
@@ -163,6 +163,7 @@ export default function Home() {
   const [playerId, setPlayerId] = useState(1);
   const [text, setText] = useState('');
   const [animationList, setAnimationList] = useState<any>([]);
+  const [contentSize, setContentSize] = useState<{width: number, height: number}>({width: 0, height: 0});
 
   useEffect(() => {
     if (initialized) {
@@ -221,9 +222,23 @@ export default function Home() {
     }, 500);
   }, []);
 
+  const checkCanvasSize = (playerRef?: HTMLElement) => {
+    const player = playerRef || document.querySelector('lottie-player');
+    const canvas = player?.querySelector('canvas');
+    if (!player || !canvas) {
+      return;
+    }
+
+    setContentSize({
+      width: canvas.width,
+      height: canvas.height
+    });
+  };
+
   const handleSliderChange = (value: number) => {
     setSize({ width: value, height: value });
     setQueryStringParameter('size', value);
+    requestAnimationFrame(() => checkCanvasSize());
   };
 
   const loadCanvasKit = async () => {
@@ -435,7 +450,9 @@ export default function Home() {
                 Set
               </button>
               <div className="text-white w-full sm:flex-1 sm:min-w-[240px]">
-                <label className="block mb-2">Box Size: {size.width}px</label>
+                <label className="block mb-2">
+                  Size: {contentSize.width}px
+                </label>
                 <input
                   type="range"
                   min={50}
@@ -494,6 +511,11 @@ export default function Home() {
                     autoplay
                     wasmUrl={wasmUrl}
                     renderConfig={JSON.stringify({enableDevicePixelRatio: true})}
+                    ref={(playerRef: HTMLElement) => {
+                      if (playerRef && index === 0) {
+                        requestAnimationFrame(() => checkCanvasSize(playerRef));
+                      }
+                    }}
                   />
                 )
               }
@@ -512,6 +534,11 @@ export default function Home() {
                       enableDevicePixelRatio: true,
                       renderer: 'wg'
                     })}
+                    ref={(playerRef: HTMLElement) => {
+                      if (playerRef && index === 0) {
+                        requestAnimationFrame(() => checkCanvasSize(playerRef));
+                      }
+                    }}
                   />
                 )
               }


### PR DESCRIPTION
- Renamed “Box Size” to “Content Size” for clarity.
- Display the actual canvas dimensions in the Content Size section.

issue: #175

<img width="3024" height="1738" alt="CleanShot 2025-11-28 at 04 10 23@2x" src="https://github.com/user-attachments/assets/09b612da-0e27-4a38-bda8-4cbfed41fd79" />
