### PR TITLE
lottie: enable DPR as default

### DIFF
--- a/src/base-lottie-player.ts
+++ b/src/base-lottie-player.ts
@@ -476,7 +476,7 @@ export class BaseLottiePlayer extends LitElement {
       return;
     }
 
-    if (this.config?.enableDevicePixelRatio) {
+    if (this.config?.enableDevicePixelRatio !== false) {
       const dpr = 1 + ((window.devicePixelRatio - 1) * 0.75);
       const { width, height } = this.canvas!.getBoundingClientRect();
       this.canvas!.width = width * dpr;


### PR DESCRIPTION
DPR application is practically used nowadays, so we can consider to set `enableDevicePixelRatio` as the default to handle this.
We also discussed this previously in the following PR comment: https://github.com/thorvg/thorvg.viewer/pull/108#issuecomment-2935784505


Related: https://github.com/thorvg/thorvg.viewer/issues/107
