### PR TITLE
playground: correct radial gradient for text sample

### DIFF
--- a/playground/lib/examples/text-static.ts
+++ b/playground/lib/examples/text-static.ts
@@ -129,7 +129,7 @@ const canvas = new TVG.Canvas('#canvas', {
     .text('나눔고딕코딩(UTF-8)');
   
   //RadialGradient
-  const radialGradient = new TVG.RadialGradient(117, 264, 59);
+  const radialGradient = new TVG.RadialGradient(115, 14.5, 115, 115, 14.5);
   
   radialGradient.setStops(
     [0, [0, 255, 255, 255]],


### PR DESCRIPTION

<img width="1504" height="1726" alt="CleanShot 2026-02-05 at 16 43 36@2x" src="https://github.com/user-attachments/assets/e3c0a371-23da-4273-9b62-cb2a28e85a4e" />



related issue: https://github.com/thorvg/thorvg.web/issues/220#issuecomment-3841350634