### PR TITLE
build: Fix errors on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ canvas.render();
 
 - Node.js 20+
 - pnpm 10+
-- Emscripten SDK (for WASM builds)
+- Python 3.8+
+- Emscripten SDK 4.0.19 (for WASM builds)
 - Meson & Ninja (for native builds)
 
 ### Building from Source

--- a/wasm/wasm32.txt
+++ b/wasm/wasm32.txt
@@ -1,6 +1,6 @@
 [binaries]
-cpp = 'EMSDK:upstream/emscripten/em++.py'
-ar = 'EMSDK:upstream/emscripten/emar.py'
+cpp = ['python3', 'EMSDK:upstream/emscripten/em++.py']
+ar = ['python3', 'EMSDK:upstream/emscripten/emar.py']
 strip = '-strip'
 
 [properties]

--- a/wasm/wasm32_gl.txt
+++ b/wasm/wasm32_gl.txt
@@ -1,6 +1,6 @@
 [binaries]
-cpp = 'EMSDK:upstream/emscripten/em++.py'
-ar = 'EMSDK:upstream/emscripten/emar.py'
+cpp = ['python3', 'EMSDK:upstream/emscripten/em++.py']
+ar = ['python3', 'EMSDK:upstream/emscripten/emar.py']
 strip = '-strip'
 
 [properties]

--- a/wasm/wasm32_sw.txt
+++ b/wasm/wasm32_sw.txt
@@ -1,6 +1,6 @@
 [binaries]
-cpp = 'EMSDK:upstream/emscripten/em++.py'
-ar = 'EMSDK:upstream/emscripten/emar.py'
+cpp = ['python3', 'EMSDK:upstream/emscripten/em++.py']
+ar = ['python3', 'EMSDK:upstream/emscripten/emar.py']
 strip = '-strip'
 
 [properties]

--- a/wasm/wasm32_wg.txt
+++ b/wasm/wasm32_wg.txt
@@ -1,6 +1,6 @@
 [binaries]
-cpp = 'EMSDK:upstream/emscripten/em++.py'
-ar = 'EMSDK:upstream/emscripten/emar.py'
+cpp = ['python3', 'EMSDK:upstream/emscripten/em++.py']
+ar = ['python3', 'EMSDK:upstream/emscripten/emar.py']
 strip = '-strip'
 
 [properties]


### PR DESCRIPTION
Windows cannot run .py files as executables, so I've added `python3` to make this explicit. It should also work with other platforms. 

Some Windows installations may not define 'python3', but it was there for me. More robust detection may be needed if someone comes by with this problem.