### PR TITLE
feat(webcanvas): add method to obtain software renderer image data

### DIFF
--- a/packages/webcanvas/test/canvas.test.ts
+++ b/packages/webcanvas/test/canvas.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import type { ThorVGNamespace } from '../src/index';
-import { Canvas } from '../src/core/Canvas';
+import type { RendererType, ThorVGNamespace } from '../src/index';
+import { Canvas, GlCanvas, SwCanvas, WgCanvas } from '../src/core/Canvas';
 
 function getTVG(): ThorVGNamespace {
   return (globalThis as any).__TVG;
+}
+
+function getRenderer(): RendererType {
+  return (globalThis as any).__RENDERER;
 }
 
 const isHappyDom = () => (globalThis as any).__TEST_ENV === 'happy-dom';
@@ -21,11 +25,13 @@ describe('Canvas', () => {
   });
 
   it('constructor creates canvas', () => {
-    expect(canvas).toBeInstanceOf(Canvas);
+    const renderer = getRenderer();
+    const canvasClass = renderer === 'sw' ? SwCanvas : renderer === 'gl' ? GlCanvas : WgCanvas;
+    expect(canvas).toBeInstanceOf(canvasClass);
   });
 
   it('renderer matches configured renderer', () => {
-    const expected = (globalThis as any).__RENDERER;
+    const expected = getRenderer();
     expect(canvas.renderer).toBe(expected);
   });
 


### PR DESCRIPTION
This PR makes the canvas selector optional for the software renderer. Instead, the rendering result can be obtained by calling the `canvas.getFrameData()` method. This allows the library to be run in a worker and draw onto an OffscreenCanvas.

To enhance type safety and enable potential future API expansions, this PR splits Canvas into three separate, engine-dependent subclasses. Currently, only `SwCanvas` has additional logic. The `init` function now infers the renderer type and provides the correct canvas subclass.

I was able to successfully pass canvas ownership to a worker, initialize the library there, and play the animation in my own tests.
```js
animation.play((frame) => {
  canvas.update();
  canvas.render();

  const imageData = canvas.getFrameData();
  if (imageData) ctx.putImageData(imageData, 0, 0);
});
```
<img width="488" height="199" alt="image" src="https://github.com/user-attachments/assets/6d15fc20-a5ad-4c1e-8975-2abff5ba79ef" />


Let me know if API shape is good. I'll update the documentation and remove the part of my previous pr that fixed the Windows build (if it hadn't been merged by that time).