### PR TITLE
wasm: upgrade c++ version

### DIFF
--- a/wasm/lottie-player/meson.build
+++ b/wasm/lottie-player/meson.build
@@ -1,6 +1,6 @@
 project('thorvg-wasm-player', 'cpp',
         version : '1.0.0',
-        default_options : ['cpp_std=c++14'])
+        default_options : ['cpp_std=c++17'])
 
 cc = meson.get_compiler('cpp')
 

--- a/wasm/wasm32.txt
+++ b/wasm/wasm32.txt
@@ -11,6 +11,7 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
+cpp_std = 'c++17'
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--use-port=emdawnwebgpu']
 cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3', '--use-port=emdawnwebgpu']
 

--- a/wasm/wasm32_gl.txt
+++ b/wasm/wasm32_gl.txt
@@ -11,6 +11,7 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
+cpp_std = 'c++17'
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
 cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
 

--- a/wasm/wasm32_sw.txt
+++ b/wasm/wasm32_sw.txt
@@ -11,6 +11,7 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
+cpp_std = 'c++17'
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
 cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS']
 

--- a/wasm/wasm32_wg.txt
+++ b/wasm/wasm32_wg.txt
@@ -11,6 +11,7 @@ shared_module_suffix = 'js'
 exe_suffix = 'js'
 
 [built-in options]
+cpp_std = 'c++17'
 cpp_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--use-port=emdawnwebgpu']
 cpp_link_args = ['-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS', '--use-port=emdawnwebgpu']
 

--- a/wasm/webcanvas/meson.build
+++ b/wasm/webcanvas/meson.build
@@ -1,6 +1,6 @@
 project('thorvg-wasm-webcanvas', 'cpp',
         version : '1.0.0',
-        default_options : ['cpp_std=c++14'])
+        default_options : ['cpp_std=c++17'])
 
 cc = meson.get_compiler('cpp')
 


### PR DESCRIPTION
Verified it builds and runs well.
I've also added `cpp_std` in cross file to build static library with C++ 17 in WASM build case, while native side still rely on C++14.

issue: https://github.com/thorvg/thorvg.web/issues/190