### PR TITLE
chore(webcanvas): remove V8-specific logics

### DIFF
--- a/packages/webcanvas/src/common/errors.ts
+++ b/packages/webcanvas/src/common/errors.ts
@@ -28,11 +28,6 @@ export class ThorVGError extends Error {
     this.name = 'ThorVGError';
     this.code = code;
     this.operation = operation;
-
-    // Maintains proper stack trace for where our error was thrown (V8 only)
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, ThorVGError);
-    }
   }
 
   public static fromCode(code: ThorVGResultCode, operation: string): ThorVGError {

--- a/packages/webcanvas/src/interop/registry.ts
+++ b/packages/webcanvas/src/interop/registry.ts
@@ -63,13 +63,3 @@ if (typeof window !== 'undefined') {
     }
   });
 }
-
-// For Node.js or other environments
-if (typeof process !== 'undefined' && process.on) {
-  process.on('exit', () => {
-    if (hasModule()) {
-      const Module = getModule();
-      Module.term();
-    }
-  });
-}


### PR DESCRIPTION
WebCanvas targets modern browsers where stack traces are automatically captured via the Error constructor per ES spec.

V8-specific APIs and Node.js–targeted logic are therefore unnecessary at this stage and may introduce unsafe type issues.