### PR TITLE
fix(ci): build API document

### DIFF
--- a/.github/workflows/release-wcanvas.yml
+++ b/.github/workflows/release-wcanvas.yml
@@ -195,6 +195,7 @@ jobs:
   build-docs:
     name: Build API Documentation
     runs-on: ubuntu-latest
+    needs: validate
 
     steps:
       - name: Checkout code
@@ -214,6 +215,12 @@ jobs:
 
       - name: Install pnpm dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-webcanvas-${{ github.run_id }}
+          path: packages/webcanvas/dist/
 
       - name: Generate API Documentation
         working-directory: ./packages/webcanvas


### PR DESCRIPTION
Since the API build job does not fetch build artifacts, it fails due to missing type declarations.
Move build-docs after the validate job to ensure that only verified documentation is published and to fix the type errors.

```
src/index.ts:54:33 - error TS2307: Cannot find module '../dist/thorvg' or its corresponding type declarations.

54 import ThorVGModuleFactory from '../dist/thorvg';
```