### PR TITLE
apps: always use latest packages

### DIFF
--- a/perf-test/package.json
+++ b/perf-test/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@headlessui/react": "^2.0.3",
     "@heroicons/react": "^2.1.3",
-    "@thorvg/lottie-player": "^1.0.1",
+    "@thorvg/lottie-player": "latest",
     "glob": "^13.0.0",
     "next": "^15.1.0",
     "react": "^18",

--- a/perf-test/yarn.lock
+++ b/perf-test/yarn.lock
@@ -661,7 +661,7 @@
   resolved "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz#586e3c1fe08547ee6abf87e8fb7c99087b9c47ff"
   integrity sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==
 
-"@thorvg/lottie-player@^1.0.1":
+"@thorvg/lottie-player@latest":
   version "1.0.1"
   resolved "https://registry.npmjs.org/@thorvg/lottie-player/-/lottie-player-1.0.1.tgz#aaad77bd905c055b70171a0fd2fcfbf33e9f6791"
   integrity sha512-+CQoLctj0CCMZQGEIUhgYxm4g2iY/Xn8H3u9MmutsxpJJGtJxLrl+iLR6xATIe49abCuGzxgV7dE1wpn07pLug==

--- a/playground/package.json
+++ b/playground/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@thorvg/webcanvas": "latest",
     "@monaco-editor/react": "^4.6.0",
-    "@thorvg/webcanvas": "^1.0.0",
     "monaco-editor": "^0.55.1",
     "next": "^15.5.10",
     "prism-react-renderer": "^2.4.1",

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -411,10 +411,10 @@
   dependencies:
     tslib "^2.8.0"
 
-"@thorvg/webcanvas@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/@thorvg/webcanvas/-/webcanvas-1.0.0.tgz#fc88129355164a89ac7369d85aea8861260b94c1"
-  integrity sha512-RgcU9G9yfC2BvlC458ZOc4ytv1IkPQWbIp7NVJbOEURd9Njn17SU0I9/0nJHQtwPVTVBEu4RRfkNOZeXn430sw==
+"@thorvg/webcanvas@latest":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@thorvg/webcanvas/-/webcanvas-1.0.1.tgz#4f22cd832722a4e31b607c28427e0a9d652ff879"
+  integrity sha512-Kl03jDvPaLOkz7t8X/I1AoZaYEyuO+fXTCUhQMRanjn/8x9xKftpiVQu5MWzkNYFKZdAIhSO7yGHVDkNdfbrhg==
 
 "@tybys/wasm-util@^0.10.0":
   version "0.10.1"


### PR DESCRIPTION
No need to specify version. Always use latest, and the CI/CD infra automatically grabs correct version and publish as their purpose.