### PR TITLE
chore(examples): use distinct animation files per renderer example

### DIFF
--- a/examples/software-lite.html
+++ b/examples/software-lite.html
@@ -54,7 +54,7 @@
 
         animation.autoPlay = true;
         animation.loop = true;
-        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg/main/examples/resources/lottie/cat_loader.json";
+        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg.web/refs/heads/main/examples/resources/coin.json";
         animation.style.width = "500px";
         animation.style.height = "500px";
         animation.wasmUrl = "../packages/lottie-player/dist/sw-lite/thorvg.wasm";

--- a/examples/software.html
+++ b/examples/software.html
@@ -54,7 +54,7 @@
 
         animation.autoPlay = true;
         animation.loop = true;
-        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg/main/examples/resources/lottie/cat_loader.json";
+        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg.web/refs/heads/main/examples/resources/dancing_star.json";
         animation.style.width = "500px";
         animation.style.height = "500px";
         animation.wasmUrl = "../packages/lottie-player/dist/sw/thorvg.wasm";

--- a/examples/webgl-lite.html
+++ b/examples/webgl-lite.html
@@ -54,7 +54,7 @@
 
         animation.autoPlay = true;
         animation.loop = true;
-        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg/main/examples/resources/lottie/cat_loader.json";
+        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg.web/refs/heads/main/examples/resources/funky_chicken.json";
         animation.style.width = "500px";
         animation.style.height = "500px";
         animation.wasmUrl = "../packages/lottie-player/dist/gl-lite/thorvg.wasm";

--- a/examples/webgl.html
+++ b/examples/webgl.html
@@ -54,7 +54,7 @@
 
         animation.autoPlay = true;
         animation.loop = true;
-        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg/main/examples/resources/lottie/cat_loader.json";
+        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg.web/refs/heads/main/examples/resources/gradient_smoke.json";
         animation.style.width = "500px";
         animation.style.height = "500px";
         animation.wasmUrl = "../packages/lottie-player/dist/gl/thorvg.wasm";

--- a/examples/webgpu-lite.html
+++ b/examples/webgpu-lite.html
@@ -56,7 +56,7 @@
 
         animation.autoPlay = true;
         animation.loop = true;
-        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg.web/refs/heads/main/examples/resources/masking.json";
+        animation.src = "https://raw.githubusercontent.com/thorvg/thorvg.web/refs/heads/main/examples/resources/confetti.json";
         animation.style.width = "3000px";
         animation.style.height = "2000px";
         animation.renderConfig = { renderer: 'wg' };


### PR DESCRIPTION
- Use different lottie assets for each renderer preset to test it easier.
- To spot rendering regressions or visual differences across renderers efficiently.