### PR TITLE
lottie-player: set current state to Loading during load process

### DIFF
--- a/packages/lottie-player/src/base-lottie-player.ts
+++ b/packages/lottie-player/src/base-lottie-player.ts
@@ -583,6 +583,7 @@ export class BaseLottiePlayer extends LitElement {
    */
   public async load(src: string | object, fileType: FileType = FileType.JSON): Promise<void> {
     try {
+      this.currentState = PlayerState.Loading;
       await this._init();
       const bytes = await parseSrc(src, fileType);
       this.dispatchEvent(new CustomEvent(PlayerEvent.Ready));


### PR DESCRIPTION
issue: #253


When switching the player source from Lottie to SVG,

the player did not properly enter the loading state before rendering. 

This could lead to inconsistent behavior, especially during resizing or rapid source changes.