### PR TITLE
lottie-player: fix memory access out of bounds when resizing SVG (SW Engine)

### DIFF
--- a/wasm/lottie-player/tvgWasmLottieAnimation.cpp
+++ b/wasm/lottie-player/tvgWasmLottieAnimation.cpp
@@ -78,6 +78,8 @@ struct TvgSwEngine : TvgEngineMethod
     void resize(Canvas* canvas, uint32_t w, uint32_t h) override
     {
         std::free(buffer);
+        buffer = nullptr;
+        if (w == 0 || h == 0) return;
         buffer = (uint8_t*)std::malloc(w * h * sizeof(uint32_t));
         static_cast<SwCanvas*>(canvas)->target((uint32_t *)buffer, w, w, h, ColorSpace::ABGR8888S);
     }
@@ -357,6 +359,7 @@ public:
         errorMsg = NoError;
 
         if (!canvas || !animation) return ArrayBuffer(val(typed_memory_view<uint8_t>(0, nullptr)));
+        if (width == 0 || height == 0) return ArrayBuffer(val(typed_memory_view<uint8_t>(0, nullptr)));
 
         if (!updated) return engine->output(width, height);
 
@@ -375,6 +378,7 @@ public:
     bool update()
     {
         if (!updated) return true;
+        if (width == 0 || height == 0) return true;
 
         errorMsg = NoError;
 
@@ -418,10 +422,11 @@ public:
 
         engine->resize(canvas, width, height);
 
+        if (width == 0 || height == 0) return;
+
         auto scale = (psize[0] > psize[1]) ? width / psize[0] : height / psize[1];
         animation->picture()->scale(scale);
         animation->picture()->translate(width * 0.5f, height * 0.5f);
-
 
         updated = true;
     }


### PR DESCRIPTION
issue: https://github.com/thorvg/thorvg.viewer/issues/150


<img width="1418" height="624" alt="image" src="https://github.com/user-attachments/assets/6a22f303-347f-400e-984a-b764bcb32073" />


 `SwCanvas::target()` preserves the previous surface data when retargeting fails.

This patch changes SW resize to swap buffers only after a successful `target()`, 
keeping the previous valid buffer alive on resize failure.
