### PR TITLE
webcanvas: fix paint scale C API mismatch

### DIFF
--- a/packages/webcanvas/API_USAGE.md
+++ b/packages/webcanvas/API_USAGE.md
@@ -1258,12 +1258,11 @@ paint.rotate(angle);
 Scales the object.
 
 ```typescript
-paint.scale(sx, sy?);
+paint.scale(factor);
 ```
 
 **Parameters:**
-- `sx: number` - X-axis scale
-- `sy?: number` - Y-axis scale (defaults to sx if omitted)
+- `factor: number` - The value of the scaling factor
 
 **Returns:** `this`
 

--- a/packages/webcanvas/src/core/Canvas.ts
+++ b/packages/webcanvas/src/core/Canvas.ts
@@ -216,7 +216,7 @@ export class Canvas {
 
     // Apply DPR scale transform if enabled
     if (enableDevicePixelRatio) {
-      this.#mainScene.scale(dpr, dpr);
+      this.#mainScene.scale(dpr);
     }
 
     // Add main Scene to canvas

--- a/packages/webcanvas/src/core/Paint.ts
+++ b/packages/webcanvas/src/core/Paint.ts
@@ -124,11 +124,11 @@ export abstract class Paint extends WasmObject {
   }
 
   /**
-   * Scale the paint by (sx, sy). If sy is not provided, use sx for both
+   * Scale the paint by factor
    */
-  public scale(sx: number, sy: number = sx): this {
+  public scale(factor: number): this {
     const Module = getModule();
-    Module._tvg_paint_scale(this.ptr, sx, sy);
+    Module._tvg_paint_scale(this.ptr, factor);
     return this;
   }
 

--- a/packages/webcanvas/src/types/emscripten.d.ts
+++ b/packages/webcanvas/src/types/emscripten.d.ts
@@ -61,7 +61,7 @@ export interface ThorVGCAPI {
   // Paint functions
   _tvg_paint_translate(paint: number, x: number, y: number): number;
   _tvg_paint_rotate(paint: number, angle: number): number;
-  _tvg_paint_scale(paint: number, sx: number, sy: number): number;
+  _tvg_paint_scale(paint: number, factor: number): number;
   _tvg_paint_set_opacity(paint: number, opacity: number): number;
   _tvg_paint_get_opacity(paint: number): number;
   _tvg_paint_set_visible(paint: number, visible: number): number;

--- a/packages/webcanvas/test/shape.test.ts
+++ b/packages/webcanvas/test/shape.test.ts
@@ -139,13 +139,6 @@ describe('Paint (via Shape)', () => {
     expect(result).toBe(shape);
   });
 
-  it('scale non-uniform returns this', () => {
-    const TVG = getTVG();
-    const shape = new TVG.Shape();
-    const result = shape.scale(2, 3);
-    expect(result).toBe(shape);
-  });
-
   it('opacity setter returns this, getter returns number', () => {
     const TVG = getTVG();
     const shape = new TVG.Shape();


### PR DESCRIPTION
fix paint scale C API mismatch


### c-api

https://github.com/thorvg/thorvg/blob/7f150f36c0587b336bd40dd745ad3f25a8a6cda9/src/bindings/capi/thorvg_capi.h#L954-L964

```cpp
/**
 * @brief Scales the given Tvg_Paint object by the given factor.
 *
 * @param[in] paint The paint object to be scaled.
 * @param[in] factor The value of the scaling factor. The default value is 1.
 *
 * @retval TVG_RESULT_INSUFFICIENT_CONDITION in case a custom transform is applied.
 *
 * @see tvg_paint_set_transform()
 */
TVG_API Tvg_Result tvg_paint_scale(Tvg_Paint paint, float factor);
```

### screenshot

<img width="442" height="39" alt="image" src="https://github.com/user-attachments/assets/cf83fc44-b3d4-4583-917a-396cf6705fea" />


| | apply scale |
|-|-|
|<img width="1100" height="814" alt="image" src="https://github.com/user-attachments/assets/ae3723a4-5443-4498-8ca3-8bd31dc89038" />|<img width="1100" height="814" alt="image" src="https://github.com/user-attachments/assets/7f38c315-0feb-4626-bccb-bd79cdaaeed6" />|
