### PR TITLE
package: pin WASM version in default URL

### DIFF
--- a/packages/lottie-player/rollup.config.js
+++ b/packages/lottie-player/rollup.config.js
@@ -145,6 +145,7 @@ const createLottieConfig = (preset) => {
           '/dist': presetMap[preset].path,
           '__THORVG_VERSION__': process.env.THORVG_VERSION,
           '__RENDERER__': presetMap[preset].renderer,
+          '__PACKAGE_VERSION__': pkg.version,
         },
       }),
       nodePolyfills(),

--- a/packages/lottie-player/src/base-lottie-player.ts
+++ b/packages/lottie-player/src/base-lottie-player.ts
@@ -29,7 +29,7 @@ type LottieJson = Record<string, unknown>;
 
 const THORVG_VERSION = '__THORVG_VERSION__';
 const DEFAULT_RENDERER = '__RENDERER__';
-const _wasmUrl = 'https://unpkg.com/@thorvg/lottie-player@latest/dist/thorvg.wasm';
+const _wasmUrl = 'https://unpkg.com/@thorvg/lottie-player@__PACKAGE_VERSION__/dist/thorvg.wasm';
 export let wasmModule: MainModule | null = null;
 let _moduleRequested: boolean = false;
 

--- a/packages/webcanvas/rollup.config.js
+++ b/packages/webcanvas/rollup.config.js
@@ -46,6 +46,7 @@ const createWebCanvasConfig = () => {
         preventAssignment: true,
         values: {
           '__THORVG_VERSION__': process.env.THORVG_VERSION,
+          '__PACKAGE_VERSION__': pkg.version,
         },
       }),
       commonjs({

--- a/packages/webcanvas/src/index.ts
+++ b/packages/webcanvas/src/index.ts
@@ -56,7 +56,7 @@ import type { RendererType } from './common/constants';
 import ThorVGModuleFactory from '../dist/thorvg';
 
 const THORVG_VERSION = '__THORVG_VERSION__';
-const THORVG_WASM_URL = 'https://unpkg.com/@thorvg/webcanvas@latest/dist/thorvg.wasm';
+const THORVG_WASM_URL = 'https://unpkg.com/@thorvg/webcanvas@__PACKAGE_VERSION__/dist/thorvg.wasm';
 
 /**
  * @category Initialization


### PR DESCRIPTION
- prevent unexpected WASM updates when resolving @latest
- mitigate supply-chain risk from unpinned CDN dependencies

issue: https://github.com/thorvg/thorvg.web/issues/82