### PR TITLE
webcanvas: expose Paint class from public API

### DIFF
--- a/packages/webcanvas/src/index.ts
+++ b/packages/webcanvas/src/index.ts
@@ -39,6 +39,7 @@
  */
 
 import type { ThorVGModule } from './types/emscripten';
+import { Paint } from './core/Paint';
 import { Canvas } from './core/Canvas';
 import { Shape } from './core/Shape';
 import { Scene } from './core/Scene';
@@ -71,6 +72,7 @@ export interface InitOptions {
 }
 
 export interface ThorVGNamespace {
+  Paint: typeof Paint;
   Canvas: typeof Canvas;
   Shape: typeof Shape;
   Scene: typeof Scene;
@@ -251,6 +253,7 @@ function term(): void {
  */
 function createNamespace(): ThorVGNamespace {
   return {
+    Paint,
     Canvas,
     Shape,
     Scene,
@@ -285,7 +288,7 @@ const ThorVG = {
 export default ThorVG;
 
 // Named exports for advanced usage
-export { init, Canvas, Shape, Scene, Picture, Text, Animation, LinearGradient, RadialGradient, Font, FontsourceProvider, Accessor, constants, ThorVGResultCode, ThorVGError };
+export { init, Paint, Canvas, Shape, Scene, Picture, Text, Animation, LinearGradient, RadialGradient, Font, FontsourceProvider, Accessor, constants, ThorVGResultCode, ThorVGError };
 
 // Re-export types
 export type { CanvasOptions } from './core/Canvas';

--- a/packages/webcanvas/test/paint.test.ts
+++ b/packages/webcanvas/test/paint.test.ts
@@ -1,8 +1,32 @@
 import { describe, it, expect } from 'vitest';
 import { getTVG } from './helpers';
+import { Paint } from '../src/index';
 
 
 describe('Paint', () => {
+  it('is exported from namespace', () => {
+    const TVG = getTVG();
+    expect(TVG.Paint).toBeDefined();
+  });
+
+  it('Shape is instanceof Paint via namespace', () => {
+    const TVG = getTVG();
+    const shape = new TVG.Shape();
+    expect(shape).toBeInstanceOf(TVG.Paint);
+  });
+
+  it('Scene is instanceof Paint via namespace', () => {
+    const TVG = getTVG();
+    const scene = new TVG.Scene();
+    expect(scene).toBeInstanceOf(TVG.Paint);
+  });
+
+  it('Shape is instanceof Paint via named export', () => {
+    const TVG = getTVG();
+    const shape = new TVG.Shape();
+    expect(shape).toBeInstanceOf(Paint);
+  });
+
   it('id returns 0 by default', () => {
     const TVG = getTVG();
     const shape = new TVG.Shape();


### PR DESCRIPTION
`Paint` is the base class for all drawable objects in ThorVG, but was never exported from the public API, preventing type narrowing and user-side abstractions built on top of it.