### PR TITLE
webcanvas: multi-threaded rendering support

### DIFF
--- a/packages/webcanvas/package.json
+++ b/packages/webcanvas/package.json
@@ -10,6 +10,10 @@
       "types": "./dist/webcanvas.d.ts",
       "import": "./dist/webcanvas.esm.js",
       "require": "./dist/webcanvas.cjs.js"
+    },
+    "./thread": {
+      "types": "./dist/webcanvas.d.ts",
+      "import": "./dist/thread/webcanvas.esm.js"
     }
   },
   "publishConfig": {
@@ -57,6 +61,7 @@
     "2d graphics"
   ],
   "devDependencies": {
+    "@rollup/plugin-alias": "^5.1.1",
     "@rollup/plugin-commonjs": "^29.0.2",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^6.0.3",

--- a/packages/webcanvas/rollup.config.js
+++ b/packages/webcanvas/rollup.config.js
@@ -4,7 +4,9 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import terser from "@rollup/plugin-terser";
 import replace from '@rollup/plugin-replace';
+import alias from '@rollup/plugin-alias';
 import pkg from './package.json' assert { type: 'json' };
+import path from 'path';
 
 const name = 'ThorVG';
 const commonOutput = {
@@ -13,6 +15,49 @@ const commonOutput = {
   inlineDynamicImports: true,
   sourcemap: true,
 };
+
+const sharedPlugins = (aliasEntries = []) => [
+  ...(aliasEntries.length ? [alias({ entries: aliasEntries })] : []),
+  replace({
+    include: ['src/**/*.ts'],
+    preventAssignment: true,
+    values: {
+      '__THORVG_VERSION__': process.env.THORVG_VERSION,
+      '__PACKAGE_VERSION__': pkg.version,
+    },
+  }),
+  commonjs({
+    include: /node_modules/
+  }),
+  swc({
+    include: /\.[mc]?[jt]sx?$/,
+    exclude: /node_modules/,
+    tsconfig: "tsconfig.json",
+    jsc: {
+      parser: {
+        syntax: "typescript",
+        tsx: false,
+        decorators: false,
+        declaration: true,
+        dynamicImport: true,
+      },
+      target: "es2020",
+    },
+  }),
+  nodeResolve(),
+  terser({
+    compress: {
+      pure_getters: true,
+      passes: 3,
+      drop_console: true,
+      drop_debugger: true
+    },
+    mangle: true,
+    output: {
+      comments: false,
+    },
+  }),
+];
 
 const createWebCanvasConfig = () => {
   return {
@@ -40,52 +85,34 @@ const createWebCanvasConfig = () => {
         ...commonOutput,
       },
     ],
-    plugins: [
-      replace({
-        include: ['src/**/*.ts'],
-        preventAssignment: true,
-        values: {
-          '__THORVG_VERSION__': process.env.THORVG_VERSION,
-          '__PACKAGE_VERSION__': pkg.version,
-        },
-      }),
-      commonjs({
-        include: /node_modules/
-      }),
-      swc({
-        include: /\.[mc]?[jt]sx?$/,
-        exclude: /node_modules/,
-        tsconfig: "tsconfig.json",
-        jsc: {
-          parser: {
-            syntax: "typescript",
-            tsx: false,
-            decorators: false,
-            declaration: true,
-            dynamicImport: true,
-          },
-          target: "es2020",
-        },
-      }),
-      nodeResolve(),
-      terser({
-        compress: {
-          pure_getters: true,
-          passes: 3,
-          drop_console: true,
-          drop_debugger: true
-        },
-        mangle: true,
-        output: {
-          comments: false,
-        },
-      }),
+    plugins: sharedPlugins(),
+  };
+}
+
+const createThreadConfig = () => {
+  return {
+    input: "./src/index.ts",
+    treeshake: {
+      moduleSideEffects: false,
+      propertyReadSideEffects: false,
+      tryCatchDeoptimization: false
+    },
+    output: [
+      {
+        file: pkg.exports['./thread'].import,
+        format: "esm",
+        ...commonOutput,
+      },
     ],
+    plugins: sharedPlugins([
+      { find: '../dist/thorvg.js', replacement: path.resolve('./dist/thread/thorvg.js') },
+    ]),
   };
 }
 
 export default [
   createWebCanvasConfig(),
+  createThreadConfig(),
   {
     input: "./src/index.ts",
     treeshake: true,

--- a/packages/webcanvas/src/core/Canvas.ts
+++ b/packages/webcanvas/src/core/Canvas.ts
@@ -41,7 +41,7 @@
  * ```
  */
 
-import { getModule } from '../interop/module';
+import { getModule, getThreadCount } from '../interop/module';
 import { Paint } from './Paint';
 import { Scene } from './Scene';
 import type { RendererType } from '../common/constants';
@@ -179,8 +179,9 @@ export class Canvas {
     const physicalWidth = width * dpr;
     const physicalHeight = height * dpr;
 
-    // Create TvgCanvas with physical dimensions
-    this.#engine = new Module.TvgCanvas(renderer, selector, physicalWidth, physicalHeight);
+    // Create TvgCanvas with physical dimensions and the configured thread count.
+    const threadCount = getThreadCount();
+    this.#engine = new Module.TvgCanvas(renderer, selector, physicalWidth, physicalHeight, threadCount);
 
     // Check for errors
     const error = this.#engine.error();

--- a/packages/webcanvas/src/index.ts
+++ b/packages/webcanvas/src/index.ts
@@ -54,6 +54,7 @@ import { FontsourceProvider } from './providers/FontsourceProvider';
 import { ThorVGResultCode, ThorVGError, setGlobalErrorHandler, handleError, type ErrorHandler } from './common/errors';
 import * as constants from './common/constants';
 import type { RendererType } from './common/constants';
+import { setThreadCount } from './interop/module';
 import ThorVGModuleFactory from '../dist/thorvg';
 
 const THORVG_VERSION = '__THORVG_VERSION__';
@@ -69,6 +70,8 @@ export interface InitOptions {
   renderer?: RendererType;
   /** Global error handler for all ThorVG operations. If provided, errors will be passed to this handler instead of being thrown. */
   onError?: ErrorHandler;
+  /** Number of worker threads count. Ignored in default preset. Default: 0. */
+  threads?: number;
 }
 
 export interface ThorVGNamespace {
@@ -204,13 +207,19 @@ async function init(options: InitOptions = {}): Promise<ThorVGNamespace> {
     return createNamespace();
   }
 
-  const { locateFile, renderer = 'gl', onError } = options;
+  const { locateFile, renderer = 'gl', onError, threads = 0 } = options;
 
   // Store the renderer for use by Canvas instances
   globalRenderer = renderer;
 
   // Set the global error handler for checkResult
   setGlobalErrorHandler(onError);
+
+  setThreadCount(threads);
+
+  // Expose the thread count globally before the WASM module loads, so the thread
+  // preset can read it in its PTHREAD_POOL_SIZE expression at module init.
+  globalThis.__THORVG_THREAD_COUNT = threads;
 
   // Load WASM module
   Module = await ThorVGModuleFactory({
@@ -240,12 +249,14 @@ function term(): void {
   // Terminate ThorVG engine
   Module.term();
 
-  // Clear global reference
+  // Clear global references
   globalThis.__ThorVGModule = undefined;
+  globalThis.__THORVG_THREAD_COUNT = undefined;
 
   // Reset state
   Module = null;
   initialized = false;
+  setThreadCount(0);
 }
 
 /**

--- a/packages/webcanvas/src/interop/module.ts
+++ b/packages/webcanvas/src/interop/module.ts
@@ -36,3 +36,14 @@ export function allocString(Module: ThorVGModule, str: string): number {
   Module.HEAPU8[ptr + bytes.length] = 0;
   return ptr;
 }
+
+// Module-level worker thread count.
+let threadCount = 0;
+
+export function setThreadCount(threads: number): void {
+  threadCount = threads;
+}
+
+export function getThreadCount(): number {
+  return threadCount;
+}

--- a/packages/webcanvas/src/types/emscripten.d.ts
+++ b/packages/webcanvas/src/types/emscripten.d.ts
@@ -34,7 +34,8 @@ export interface TvgCanvasConstructor {
     engineType: string,
     selector: string,
     width: number,
-    height: number
+    height: number,
+    threads: number
   ): TvgCanvasInstance;
 }
 

--- a/packages/webcanvas/src/types/global.d.ts
+++ b/packages/webcanvas/src/types/global.d.ts
@@ -2,4 +2,5 @@ import type { ThorVGModule } from './emscripten';
 
 declare global {
   var __ThorVGModule: ThorVGModule | undefined;
+  var __THORVG_THREAD_COUNT: number | undefined;
 }

--- a/packages/webcanvas/wasm_wcanvas_build.sh
+++ b/packages/webcanvas/wasm_wcanvas_build.sh
@@ -2,11 +2,21 @@
 
 # WebCanvas WASM Build Script
 # Builds ThorVG library + WebCanvas bindings
+#
+# Usage:
+#   ./wasm_wcanvas_build.sh <EMSDK_PATH>           # default build (all engines, single-threaded)
+#   ./wasm_wcanvas_build.sh pthread <EMSDK_PATH>   # pthread build (all engines, multi-thread support)
+
+MODE="default"
+if [ "$1" = "pthread" ]; then
+  MODE="pthread"
+  shift
+fi
 
 EMSDK="$1"
 
 if [ -z "$EMSDK" ]; then
-  echo "Usage: $0 <EMSDK_PATH>"
+  echo "Usage: $0 [pthread] <EMSDK_PATH>"
   exit 1
 fi
 
@@ -28,12 +38,24 @@ rm -rf build_wasm_wcanvas
 # 2. Remove -fno-exceptions from cpp_args
 # 3. Remove --closure=1 and -sEXPORTED_RUNTIME_METHODS=FS from cpp_link_args
 # 4. Add WebCanvas specific flags: EXPORTED_FUNCTIONS, EXPORTED_RUNTIME_METHODS, exception handling, and TypeScript definitions
-sed "s|EMSDK:|$EMSDK/|g" ../wasm/wasm32.txt | \
-  sed "s|, '-fno-exceptions'||g" | \
-  sed "s|'-fno-exceptions', ||g" | \
-  sed "s|, '--closure=1'||g" | \
-  sed "s|, '-sEXPORTED_RUNTIME_METHODS=FS'||g" | \
-  sed "s|'--bind'|'--bind', '--emit-tsd=thorvg.d.ts', '-sEXPORTED_FUNCTIONS=${EXPORTED_FUNCTIONS}', '-sEXPORTED_RUNTIME_METHODS=${EXPORTED_RUNTIME_METHODS}', '-sDISABLE_EXCEPTION_CATCHING=0', '-sDISABLE_EXCEPTION_THROWING=0', '-sALLOW_TABLE_GROWTH=1', '-sINITIAL_TABLE=128'|g" > /tmp/.wasm_webcanvas_cross.txt
+# 5. For pthread builds: also add -pthread to cpp_args/cpp_link_args plus SharedArrayBuffer memory
+#    settings, and a dynamic worker pool size via PTHREAD_POOL_SIZE.
+if [ "$MODE" = "pthread" ]; then
+  sed "s|EMSDK:|$EMSDK/|g" ../wasm/wasm32.txt | \
+    sed "s|, '-fno-exceptions'||g" | \
+    sed "s|'-fno-exceptions', ||g" | \
+    sed "s|, '--closure=1'||g" | \
+    sed "s|, '-sEXPORTED_RUNTIME_METHODS=FS'||g" | \
+    sed "s|cpp_args = \[|cpp_args = ['-pthread', |g" | \
+    sed "s|'--bind'|'--bind', '-pthread', '--emit-tsd=thorvg.d.ts', '-sPTHREAD_POOL_SIZE=(typeof globalThis.__THORVG_THREAD_COUNT !== \"undefined\" ? globalThis.__THORVG_THREAD_COUNT : (typeof navigator !== \"undefined\" \&\& navigator.hardwareConcurrency ? navigator.hardwareConcurrency : 4))', '-sPTHREAD_POOL_SIZE_STRICT=0', '-sINITIAL_MEMORY=134217728', '-sEXPORTED_FUNCTIONS=${EXPORTED_FUNCTIONS}', '-sEXPORTED_RUNTIME_METHODS=${EXPORTED_RUNTIME_METHODS}', '-sDISABLE_EXCEPTION_CATCHING=0', '-sDISABLE_EXCEPTION_THROWING=0', '-sALLOW_TABLE_GROWTH=1', '-sINITIAL_TABLE=128'|g" > /tmp/.wasm_webcanvas_cross.txt
+else
+  sed "s|EMSDK:|$EMSDK/|g" ../wasm/wasm32.txt | \
+    sed "s|, '-fno-exceptions'||g" | \
+    sed "s|'-fno-exceptions', ||g" | \
+    sed "s|, '--closure=1'||g" | \
+    sed "s|, '-sEXPORTED_RUNTIME_METHODS=FS'||g" | \
+    sed "s|'--bind'|'--bind', '--emit-tsd=thorvg.d.ts', '-sEXPORTED_FUNCTIONS=${EXPORTED_FUNCTIONS}', '-sEXPORTED_RUNTIME_METHODS=${EXPORTED_RUNTIME_METHODS}', '-sDISABLE_EXCEPTION_CATCHING=0', '-sDISABLE_EXCEPTION_THROWING=0', '-sALLOW_TABLE_GROWTH=1', '-sINITIAL_TABLE=128'|g" > /tmp/.wasm_webcanvas_cross.txt
+fi
 
 meson setup \
   -Db_lto=true \
@@ -41,7 +63,7 @@ meson setup \
   -Dstatic=true \
   -Dloaders="all" \
   -Dsavers="all" \
-  -Dthreads=false \
+  -Dthreads="$([ "$MODE" = "pthread" ] && echo true || echo false)" \
   -Dfile="false" \
   -Dbindings="capi" \
   -Dpartial=true \
@@ -84,5 +106,5 @@ fi
 
 rm ../../wasm/webcanvas/config.h
 
-echo "Build completed successfully!"
+echo "Build completed successfully! (mode: ${MODE})"
 ls -lrt build_wasm_wcanvas/*.js build_wasm_wcanvas/*.wasm

--- a/packages/webcanvas/wasm_wcanvas_setup.sh
+++ b/packages/webcanvas/wasm_wcanvas_setup.sh
@@ -12,10 +12,8 @@ if [ -z "$EMSDK" ]; then
 fi
 
 # Build WASM with all backends (sw, gl, wg)
-echo "Building ThorVG WASM with WebCanvas bindings..."
-sh ./wasm_wcanvas_build.sh "$EMSDK/"
-
-if [ $? -ne 0 ]; then
+echo "Building ThorVG WASM with WebCanvas bindings (default)..."
+if ! sh ./wasm_wcanvas_build.sh "$EMSDK/"; then
   echo "WASM build failed!"
   exit 1
 fi
@@ -25,5 +23,20 @@ mv build_wasm_wcanvas/thorvg.js ./dist/
 mv build_wasm_wcanvas/thorvg.wasm ./dist/
 mv build_wasm_wcanvas/thorvg.d.ts ./dist/
 
+# Build WASM with pthread support
+echo "Building ThorVG WASM with WebCanvas bindings (pthread)..."
+if ! sh ./wasm_wcanvas_build.sh pthread "$EMSDK/"; then
+  echo "Pthread WASM build failed!"
+  exit 1
+fi
+
+mkdir -p ./dist/thread
+mv build_wasm_wcanvas/thorvg.js ./dist/thread/
+mv build_wasm_wcanvas/thorvg.wasm ./dist/thread/
+if [ -f build_wasm_wcanvas/thorvg.worker.js ]; then
+  mv build_wasm_wcanvas/thorvg.worker.js ./dist/thread/
+fi
+rm -f build_wasm_wcanvas/thorvg.d.ts
+
 echo "WASM setup completed successfully!"
-ls -lh ./dist/thorvg.*
+ls -lh ./dist/thorvg.* ./dist/thread/thorvg.* 2>/dev/null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
 
   packages/webcanvas:
     devDependencies:
+      '@rollup/plugin-alias':
+        specifier: ^5.1.1
+        version: 5.1.1(rollup@4.60.1)
       '@rollup/plugin-commonjs':
         specifier: ^29.0.2
         version: 29.0.2(rollup@4.60.1)
@@ -1119,6 +1122,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/browser-playwright@4.1.4':
     resolution: {integrity: sha512-q3PchVhZINX23Pv+RERgAtDlp6wzVkID/smOPnZ5YGWpeWUe3jMNYppeVh15j4il3G7JIJty1d1Kicpm0HSMig==}

--- a/wasm/webcanvas/tvgWasmWebCanvas.cpp
+++ b/wasm/webcanvas/tvgWasmWebCanvas.cpp
@@ -38,7 +38,7 @@ EMSCRIPTEN_DECLARE_VAL_TYPE(ArrayBuffer);
 struct TvgEngineMethod
 {
     virtual ~TvgEngineMethod() {}
-    virtual Canvas* init(string& selector) = 0;
+    virtual Canvas* init(string& selector, uint32_t threads) = 0;
     virtual void resize(Canvas* canvas, uint32_t w, uint32_t h) = 0;
     virtual ArrayBuffer output(uint32_t w, uint32_t h)
     {
@@ -63,9 +63,9 @@ struct TvgSwEngine : TvgEngineMethod
         retrieveFont();
     }
 
-    Canvas* init(string& selector) override
+    Canvas* init(string& selector, uint32_t threads) override
     {
-        if (Initializer::init() != Result::Success) return nullptr;
+        if (Initializer::init(threads) != Result::Success) return nullptr;
         loadFont();
         return SwCanvas::gen(EngineOption::SmartRender);
     }
@@ -109,7 +109,7 @@ struct TvgWgEngine : TvgEngineMethod
         retrieveFont();
     }
 
-    Canvas* init(string& selector) override
+    Canvas* init(string& selector, uint32_t threads) override
     {
         // Create WebGPU surface
         WGPUEmscriptenSurfaceSourceCanvasHTMLSelector canvasDesc{};
@@ -124,7 +124,7 @@ struct TvgWgEngine : TvgEngineMethod
 
         if (!surface) return nullptr;
 
-        if (Initializer::init() != Result::Success) return nullptr;
+        if (Initializer::init(threads) != Result::Success) return nullptr;
         loadFont();
 
         return WgCanvas::gen(EngineOption::Default);
@@ -240,7 +240,7 @@ struct TvgGlEngine : TvgEngineMethod
         retrieveFont();
     }
 
-    Canvas* init(string& selector) override
+    Canvas* init(string& selector, uint32_t threads) override
     {
         EmscriptenWebGLContextAttributes attrs{};
         attrs.alpha = true;
@@ -257,7 +257,7 @@ struct TvgGlEngine : TvgEngineMethod
 
         emscripten_webgl_make_context_current(context);
 
-        if (Initializer::init() != Result::Success) return nullptr;
+        if (Initializer::init(threads) != Result::Success) return nullptr;
         loadFont();
 
         return GlCanvas::gen(EngineOption::Default);
@@ -297,7 +297,7 @@ public:
         if (engine) delete engine;
     }
 
-    explicit TvgCanvas(string engineType = "sw", string selector = "", uint32_t w = 0, uint32_t h = 0) {
+    explicit TvgCanvas(string engineType = "sw", string selector = "", uint32_t w = 0, uint32_t h = 0, uint32_t threads = 0) {
         errorMsg = "None";
 
 #ifdef THORVG_CPU_ENGINE_SUPPORT
@@ -315,7 +315,7 @@ public:
             return;
         }
 
-        canvas = engine->init(selector);
+        canvas = engine->init(selector, threads);
         if (!canvas) {
             errorMsg = "Canvas initialization failed";
             return;
@@ -379,7 +379,7 @@ EMSCRIPTEN_BINDINGS(thorvg_webcanvas) {
     emscripten::function("term", &term);
 
     class_<TvgCanvas>("TvgCanvas")
-        .constructor<string, string, uint32_t, uint32_t>()
+        .constructor<string, string, uint32_t, uint32_t, uint32_t>()
         .function("error", &TvgCanvas::error)
         .function("resize", &TvgCanvas::resize)
         .function("clear", &TvgCanvas::clear)


### PR DESCRIPTION
Added a thread preset build, compiled with Emscripten pthread support.

usage:
```ts
import ThorVG from '@thorvg/webcanvas/thread';

const TVG = await ThorVG.init({
    renderer: 'sw',
    threads: navigator.hardwareConcurrency,
});
const canvas = new TVG.Canvas('#canvas', { width: 800, height: 600 });
```

issue: https://github.com/thorvg/thorvg.web/issues/286