### PR TITLE
lottie: fix raf leak when starting new loop

### DIFF
--- a/packages/lottie-player/src/base-lottie-player.ts
+++ b/packages/lottie-player/src/base-lottie-player.ts
@@ -327,6 +327,7 @@ export class BaseLottiePlayer extends LitElement {
   private _timer?: ReturnType<typeof setInterval>;
   private _observer?: IntersectionObserver;
   private _observable: boolean = false;
+  private _rafId?: number;
   private _assetResolverCallback?: (src: string, data: unknown) => { name: string, buffer: ArrayBuffer, mimetype: string };
   private _assetResolverData?: unknown;
 
@@ -445,6 +446,13 @@ export class BaseLottiePlayer extends LitElement {
     return this;
   }
 
+  private _startLoop(): void {
+    if (this._rafId) {
+      window.cancelAnimationFrame(this._rafId);
+    }
+    this._rafId = window.requestAnimationFrame(this._animLoop.bind(this));
+  }
+
   private async _animLoop(){
     if (!this.TVG) {
       return;
@@ -452,7 +460,7 @@ export class BaseLottiePlayer extends LitElement {
 
     if (await this._update()) {
       this._render();
-      window.requestAnimationFrame(this._animLoop.bind(this));
+      this._rafId = window.requestAnimationFrame(this._animLoop.bind(this));
     }
   }
 
@@ -623,7 +631,7 @@ export class BaseLottiePlayer extends LitElement {
 
     if (this._observable) {
       this.currentState = PlayerState.Playing;
-      window.requestAnimationFrame(this._animLoop.bind(this));
+      this._startLoop();
       return;
     }
 


### PR DESCRIPTION
Loading a new animation before the current play loop has terminated causes play() (invoked during load()) to schedule another render loop without cancelling the existing one, so the loops stack and accumulate.

### Regression Overview
- since : v1.0.3
- curprit : https://github.com/thorvg/thorvg.web/commit/bd8a8912733c8227611f1311e39f8a38444b0531

Until v1.0.2, single animation loop was retained when loading animation during existing playback.
By v1.0.3, when `load()` called, changed currentState triggers new animation loop without original loop termination, causing RAF leak.