### PR TITLE
lottie: update stop() state correctly

### DIFF
--- a/packages/lottie-player/src/base-lottie-player.ts
+++ b/packages/lottie-player/src/base-lottie-player.ts
@@ -652,10 +652,10 @@ export class BaseLottiePlayer extends LitElement {
    * @since 1.0
    */
   public stop(): void {
-    this.currentState = PlayerState.Stopped;
-    this.currentFrame = 0;
-    this._counter = 1;
     this.seek(0);
+    this._counter = 1;
+    this.currentFrame = 0;
+    this.currentState = PlayerState.Stopped;
 
     this.dispatchEvent(new CustomEvent(PlayerEvent.Stop));
   }

--- a/packages/lottie-player/tests/lottie-player.test.ts
+++ b/packages/lottie-player/tests/lottie-player.test.ts
@@ -130,7 +130,7 @@ describe('Lottie Player', () => {
     it('stop resets to frame 0', async () => {
       player.stop();
       await player.updateComplete;
-      expect(player.currentState).to.equal('paused');
+      expect(player.currentState).to.equal('stopped');
       expect(player.currentFrame).to.equal(0);
     });
 


### PR DESCRIPTION
Previously, stop() incorrectly settled on the `paused` state. Align the playback state and test case.