### PR TITLE
wasm: use premultiplied color space for webgpu

### DIFF
--- a/wasm/lottie-player/tvgWasmLottieAnimation.cpp
+++ b/wasm/lottie-player/tvgWasmLottieAnimation.cpp
@@ -134,7 +134,7 @@ struct TvgWgEngine : TvgEngineMethod
 
     void resize(Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        if (canvas) static_cast<WgCanvas*>(canvas)->target(device, instance, surface, w, h, ColorSpace::ABGR8888S);
+        if (canvas) static_cast<WgCanvas*>(canvas)->target(device, instance, surface, w, h, ColorSpace::ABGR8888);
     }
 
     static int init()


### PR DESCRIPTION
Pass ColorSpace::ABGR8888 to the WebGPU canvas target in the Lottie WASM bridge. This matches the premultiplied surface expectation used by the WebGPU renderer branch.

This PR can be merged only after https://github.com/thorvg/thorvg/pull/4471 has been merged.