### PR TITLE
wasm: pass WebGPU adapter context

### DIFF
--- a/wasm/lottie-player/tvgWasmLottieAnimation.cpp
+++ b/wasm/lottie-player/tvgWasmLottieAnimation.cpp
@@ -134,7 +134,7 @@ struct TvgWgEngine : TvgEngineMethod
 
     void resize(Canvas* canvas, uint32_t w, uint32_t h) override
     {
-        if (canvas) static_cast<WgCanvas*>(canvas)->target(device, instance, surface, w, h, ColorSpace::ABGR8888S);
+        if (canvas) static_cast<WgCanvas*>(canvas)->target({instance, adapter, device}, surface, w, h, ColorSpace::ABGR8888);
     }
 
     static int init()

--- a/wasm/webcanvas/tvgWasmWebCanvas.cpp
+++ b/wasm/webcanvas/tvgWasmWebCanvas.cpp
@@ -134,9 +134,7 @@ struct TvgWgEngine : TvgEngineMethod
     {
         if (!canvas) return;
 
-        static_cast<WgCanvas*>(canvas)->target(
-            device, instance, surface, w, h, ColorSpace::ABGR8888S
-        );
+        static_cast<WgCanvas*>(canvas)->target({instance, adapter, device}, surface, w, h, ColorSpace::ABGR8888);
     }
 
     static int init()


### PR DESCRIPTION
## Summary
ThorVG v1.0.7 already provides the WebGPU context target API that carries the adapter, so avoid moving the submodule past the repo's pinned release.

Pass {instance, adapter, device} into WgCanvas::target from both WASM bridges. Keep the JS-provided adapter available to the renderer with the smallest source change needed for the v1.0.7 API.

## Validation
<img width="1392" height="856" alt="Screenshot 2026-07-07 at 3 17 36 PM" src="https://github.com/user-attachments/assets/fccfd729-52d9-4c60-8cee-dfe3b609edb2" />
I have tested it manually.