### PR TITLE
webcanvas: remove obsolete enum

### DIFF
--- a/packages/webcanvas/API_USAGE.md
+++ b/packages/webcanvas/API_USAGE.md
@@ -1453,23 +1453,6 @@ enum GradientSpread {
 
 ---
 
-### CompositeMethod
-
-Composite methods (future support).
-
-```typescript
-enum CompositeMethod {
-  None = 0,
-  ClipPath = 1,
-  AlphaMask = 2,
-  InvAlphaMask = 3,
-  LumaMask = 4,
-  InvLumaMask = 5,
-}
-```
-
----
-
 ### TextWrapMode
 
 Text wrapping modes.

--- a/packages/webcanvas/src/common/constants.ts
+++ b/packages/webcanvas/src/common/constants.ts
@@ -109,27 +109,6 @@ export enum GradientSpread {
 }
 
 /**
- * Composite method for combining paint objects.
- *
- * Defines methods for compositing operations such as clipping and masking.
- * @category Constants
- */
-export enum CompositeMethod {
-  /** No compositing is applied */
-  None = 0,
-  /** Use the paint as a clipping path */
-  ClipPath = 1,
-  /** Alpha masking using the mask's alpha values */
-  AlphaMask = 2,
-  /** Inverse alpha masking using the complement of the mask's alpha values */
-  InvAlphaMask = 3,
-  /** Luma masking using the grayscale of the mask */
-  LumaMask = 4,
-  /** Inverse luma masking using the complement of the mask's grayscale */
-  InvLumaMask = 5,
-}
-
-/**
  * Mask method for masking operations.
  *
  * Defines various methods for applying masks to paint objects.

--- a/packages/webcanvas/src/index.ts
+++ b/packages/webcanvas/src/index.ts
@@ -92,7 +92,6 @@ export interface ThorVGNamespace {
   StrokeJoin: typeof constants.StrokeJoin;
   FillRule: typeof constants.FillRule;
   GradientSpread: typeof constants.GradientSpread;
-  CompositeMethod: typeof constants.CompositeMethod;
   MaskMethod: typeof constants.MaskMethod;
   SceneEffect: typeof constants.SceneEffect;
   TextWrapMode: typeof constants.TextWrapMode;
@@ -281,7 +280,6 @@ function createNamespace(): ThorVGNamespace {
     StrokeJoin: constants.StrokeJoin,
     FillRule: constants.FillRule,
     GradientSpread: constants.GradientSpread,
-    CompositeMethod: constants.CompositeMethod,
     MaskMethod: constants.MaskMethod,
     SceneEffect: constants.SceneEffect,
     TextWrapMode: constants.TextWrapMode,


### PR DESCRIPTION
A leftover from the pre-1.0 API that is no longer used.