### PR TITLE
webcanvas: support EngineOption for canvas creation

### DIFF
--- a/packages/webcanvas/src/common/constants.ts
+++ b/packages/webcanvas/src/common/constants.ts
@@ -157,6 +157,20 @@ export enum MaskMethod {
 }
 
 /**
+ * Enumeration to specify rendering engine behavior.
+ *
+ * The availability or behavior of SmartRender may vary depending on backend support.
+ * Currently only the 'sw' renderer supports it.
+ * @category Canvas
+ */
+export enum EngineOption {
+  /** No engine options are enabled. This may be used to explicitly disable all optional behaviors */
+  None = 0,
+  /** Enables automatic partial (smart) rendering optimizations */
+  SmartRender = 1 << 1,
+}
+
+/**
  * Scene effect for post-processing effects.
  *
  * Defines various visual effects that can be applied to a Scene to modify its final appearance.

--- a/packages/webcanvas/src/core/Canvas.ts
+++ b/packages/webcanvas/src/core/Canvas.ts
@@ -44,6 +44,7 @@
 import { getModule, getThreadCount } from '../interop/module';
 import { Paint } from './Paint';
 import { Scene } from './Scene';
+import { EngineOption } from '../common/constants';
 import type { RendererType } from '../common/constants';
 import { checkResult, handleError } from '../common/errors';
 import type { TvgCanvasInstance } from '../types/emscripten';
@@ -61,6 +62,8 @@ export interface CanvasOptions {
   height?: number;
   /** Enable device pixel ratio for high-DPI displays. Default: true */
   enableDevicePixelRatio?: boolean;
+  /** Rendering engine behavior option. Default: EngineOption.SmartRender */
+  engineOption?: EngineOption;
 }
 
 /**
@@ -156,9 +159,18 @@ export class Canvas {
    *   enableDevicePixelRatio: false
    * });
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Disable smart rendering for full-redraw scenes (SW renderer)
+   * const TVG = await ThorVG.init({ renderer: 'sw' });
+   * const canvas = new TVG.Canvas('#canvas', {
+   *   engineOption: TVG.EngineOption.None
+   * });
+   * ```
    */
   constructor(selector: string, options: CanvasOptions = {}) {
-    const { width = 800, height = 600, enableDevicePixelRatio = true } = options;
+    const { width = 800, height = 600, enableDevicePixelRatio = true, engineOption = EngineOption.SmartRender } = options;
 
     // Store logical dimensions
     this.#logicalWidth = width;
@@ -181,7 +193,7 @@ export class Canvas {
 
     // Create TvgCanvas with physical dimensions and the configured thread count.
     const threadCount = getThreadCount();
-    this.#engine = new Module.TvgCanvas(renderer, selector, physicalWidth, physicalHeight, threadCount);
+    this.#engine = new Module.TvgCanvas(renderer, selector, physicalWidth, physicalHeight, threadCount, engineOption);
 
     // Check for errors
     const error = this.#engine.error();

--- a/packages/webcanvas/src/index.ts
+++ b/packages/webcanvas/src/index.ts
@@ -100,6 +100,7 @@ export interface ThorVGNamespace {
   TextWrapMode: typeof constants.TextWrapMode;
   ColorSpace: typeof constants.ColorSpace;
   FilterMethod: typeof constants.FilterMethod;
+  EngineOption: typeof constants.EngineOption;
   /** ThorVG engine version string */
   version: string;
   term(): void;
@@ -291,6 +292,7 @@ function createNamespace(): ThorVGNamespace {
     TextWrapMode: constants.TextWrapMode,
     ColorSpace: constants.ColorSpace,
     FilterMethod: constants.FilterMethod,
+    EngineOption: constants.EngineOption,
     version: THORVG_VERSION,
     term,
   };

--- a/packages/webcanvas/src/types/emscripten.d.ts
+++ b/packages/webcanvas/src/types/emscripten.d.ts
@@ -39,7 +39,8 @@ export interface TvgCanvasConstructor {
     selector: string,
     width: number,
     height: number,
-    threads: number
+    threads: number,
+    engineOption: number
   ): TvgCanvasInstance;
 }
 

--- a/packages/webcanvas/test/canvas.test.ts
+++ b/packages/webcanvas/test/canvas.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { getTVG } from './helpers';
 import { Canvas } from '../src/core/Canvas';
+import { EngineOption } from '../src/common/constants';
 
 
 const isHappyDom = () => globalThis.__TEST_ENV === 'happy-dom';
@@ -72,5 +73,29 @@ describe('Canvas', () => {
   it.skipIf(isHappyDom())('clear returns this', () => {
     const result = canvas.clear();
     expect(result).toBe(canvas);
+  });
+});
+
+describe('Canvas engineOption', () => {
+  function createCanvasWith(engineOption: EngineOption): Canvas {
+    const TVG = getTVG();
+    const id = `tvg-engine-option-${engineOption}`;
+    const el = document.createElement('canvas');
+    el.id = id;
+    document.body.appendChild(el);
+    const tvg = new TVG.Canvas(`#${id}`, { width: 100, height: 100, engineOption });
+    return tvg;
+  }
+
+  it('constructor accepts EngineOption.SmartRender', () => {
+    const tvg = createCanvasWith(EngineOption.SmartRender);
+    expect(tvg).toBeInstanceOf(Canvas);
+    tvg.destroy();
+  });
+
+  it('constructor accepts EngineOption.None', () => {
+    const tvg = createCanvasWith(EngineOption.None);
+    expect(tvg).toBeInstanceOf(Canvas);
+    tvg.destroy();
   });
 });

--- a/wasm/webcanvas/tvgWasmWebCanvas.cpp
+++ b/wasm/webcanvas/tvgWasmWebCanvas.cpp
@@ -38,7 +38,7 @@ EMSCRIPTEN_DECLARE_VAL_TYPE(ArrayBuffer);
 struct TvgEngineMethod
 {
     virtual ~TvgEngineMethod() {}
-    virtual Canvas* init(string& selector, uint32_t threads) = 0;
+    virtual Canvas* init(string& selector, uint32_t threads, EngineOption op) = 0;
     virtual void resize(Canvas* canvas, uint32_t w, uint32_t h) = 0;
     virtual ArrayBuffer output(uint32_t w, uint32_t h)
     {
@@ -63,11 +63,11 @@ struct TvgSwEngine : TvgEngineMethod
         retrieveFont();
     }
 
-    Canvas* init(string& selector, uint32_t threads) override
+    Canvas* init(string& selector, uint32_t threads, EngineOption op) override
     {
         if (Initializer::init(threads) != Result::Success) return nullptr;
         loadFont();
-        return SwCanvas::gen(EngineOption::SmartRender);
+        return SwCanvas::gen(op);
     }
 
     void resize(Canvas* canvas, uint32_t w, uint32_t h) override
@@ -109,7 +109,7 @@ struct TvgWgEngine : TvgEngineMethod
         retrieveFont();
     }
 
-    Canvas* init(string& selector, uint32_t threads) override
+    Canvas* init(string& selector, uint32_t threads, EngineOption op) override
     {
         // Create WebGPU surface
         WGPUEmscriptenSurfaceSourceCanvasHTMLSelector canvasDesc{};
@@ -127,7 +127,7 @@ struct TvgWgEngine : TvgEngineMethod
         if (Initializer::init(threads) != Result::Success) return nullptr;
         loadFont();
 
-        return WgCanvas::gen(EngineOption::Default);
+        return WgCanvas::gen(op);
     }
 
     void resize(Canvas* canvas, uint32_t w, uint32_t h) override
@@ -240,7 +240,7 @@ struct TvgGlEngine : TvgEngineMethod
         retrieveFont();
     }
 
-    Canvas* init(string& selector, uint32_t threads) override
+    Canvas* init(string& selector, uint32_t threads, EngineOption op) override
     {
         EmscriptenWebGLContextAttributes attrs{};
         attrs.alpha = true;
@@ -260,7 +260,7 @@ struct TvgGlEngine : TvgEngineMethod
         if (Initializer::init(threads) != Result::Success) return nullptr;
         loadFont();
 
-        return GlCanvas::gen(EngineOption::Default);
+        return GlCanvas::gen(op);
     }
 
     void resize(Canvas* canvas, uint32_t w, uint32_t h) override
@@ -297,7 +297,7 @@ public:
         if (engine) delete engine;
     }
 
-    explicit TvgCanvas(string engineType = "sw", string selector = "", uint32_t w = 0, uint32_t h = 0, uint32_t threads = 0) {
+    explicit TvgCanvas(string engineType = "sw", string selector = "", uint32_t w = 0, uint32_t h = 0, uint32_t threads = 0, uint32_t engineOption = static_cast<uint32_t>(EngineOption::SmartRender)) {
         errorMsg = "None";
 
 #ifdef THORVG_CPU_ENGINE_SUPPORT
@@ -315,7 +315,7 @@ public:
             return;
         }
 
-        canvas = engine->init(selector, threads);
+        canvas = engine->init(selector, threads, static_cast<EngineOption>(engineOption));
         if (!canvas) {
             errorMsg = "Canvas initialization failed";
             return;
@@ -379,7 +379,7 @@ EMSCRIPTEN_BINDINGS(thorvg_webcanvas) {
     emscripten::function("term", &term);
 
     class_<TvgCanvas>("TvgCanvas")
-        .constructor<string, string, uint32_t, uint32_t, uint32_t>()
+        .constructor<string, string, uint32_t, uint32_t, uint32_t, uint32_t>()
         .function("error", &TvgCanvas::error)
         .function("resize", &TvgCanvas::resize)
         .function("clear", &TvgCanvas::clear)


### PR DESCRIPTION
usage:
```
const TVG = await ThorVG.init({ renderer: 'sw' });
const canvas = new TVG.Canvas('#canvas', {
  engineOption: TVG.EngineOption.None,  // default: SmartRender
});
```