### PR TITLE
infra: allow fork PR checkout in preview workflows

### DIFF
--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
+          allow-unsafe-pr-checkout: true # required reviewers (environment: external)
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
+          allow-unsafe-pr-checkout: true # required reviewers (environment: external)
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
these jobs are already gated by required
reviewers on the 'external' environment.