### PR TITLE
docs: fix broken README images on out of github

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # ThorVG for Web
 
 <p align="center">
-  <img width="550" height="auto" src="https://github.com/thorvg/thorvg.site/blob/main/readme/logo/animated_brand.svg">
+  <img width="550" height="auto" src="https://raw.githubusercontent.com/thorvg/thorvg.site/main/readme/logo/animated_brand.svg">
 </p>
 
 **ThorVG.Web** is a WebAssembly (WASM)-based extension of the ThorVG vector graphics engine, designed to run seamlessly in modern web environments. It enables efficient and high-performance rendering of **vector graphics** and **Lottie animations** directly in the browser, leveraging both **WebGL** and **WebGPU** for hardware-accelerated rendering. Fully compatible with ThorVG's core rendering logic, ThorVG.Web ensures consistent output across desktop, mobile, and web platforms, allowing developers to reuse the same vector assets and rendering code across multiple targets with minimal changes.

--- a/packages/lottie-player/README.md
+++ b/packages/lottie-player/README.md
@@ -1,6 +1,6 @@
 # ThorVG for Web
 <p align="center">
-  <img width="800" height="auto" src="https://github.com/thorvg/thorvg.site/blob/main/readme/logo/512/thorvg-banner.png">
+  <img width="800" height="auto" src="https://raw.githubusercontent.com/thorvg/thorvg.site/main/readme/logo/512/thorvg-banner.png">
 </p>
 
 [![npm](https://img.shields.io/npm/v/@thorvg/lottie-player)](https://www.npmjs.com/package/@thorvg/lottie-player)

--- a/packages/webcanvas/README.md
+++ b/packages/webcanvas/README.md
@@ -1,6 +1,6 @@
 # ThorVG for Web
 <p align="center">
-  <img width="800" height="auto" src="https://github.com/thorvg/thorvg.site/blob/main/readme/logo/512/thorvg-banner.png">
+  <img width="800" height="auto" src="https://raw.githubusercontent.com/thorvg/thorvg.site/main/readme/logo/512/thorvg-banner.png">
 </p>
 
 [![npm](https://img.shields.io/npm/v/@thorvg/webcanvas)](https://www.npmjs.com/package/@thorvg/webcanvas)
@@ -76,7 +76,7 @@ canvas.add(circle);                                        // add the circle to 
 This code generates the following result:
 
 <p align="center">
-  <img width="416" height="auto" src="https://github.com/thorvg/thorvg.site/blob/main/readme/example_shapes.png">
+  <img width="416" height="auto" src="https://raw.githubusercontent.com/thorvg/thorvg.site/main/readme/example_shapes.png">
 </p>
 
 You can also draw your own shapes and use dashed stroking:
@@ -111,7 +111,7 @@ canvas.add(path);                                          // add the path to th
 The code generates the following result:
 
 <p align="center">
-  <img width="300" height="auto" src="https://github.com/thorvg/thorvg.site/blob/main/readme/example_path.png">
+  <img width="300" height="auto" src="https://raw.githubusercontent.com/thorvg/thorvg.site/main/readme/example_path.png">
 </p>
 
 Now begin rendering & finish it at a particular time:


### PR DESCRIPTION
No visual changes. The `github.com` isn't allowed to serve image files in external pages such as CDN landing pages, ETC. Replacing URL to official file serving URL `raw.githubusercontent.com` to avoid missing images problem.