### PR TITLE
ci: skip workflows on test-only changes

### DIFF
--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -10,6 +10,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/build-react.yml'
       - '!**/*.md'
+      - '!packages/*/test*/**'
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/build-react.yml'
       - '!**/*.md'
+      - '!packages/*/test*/**'
 
 jobs:
   build-react-example:

--- a/.github/workflows/build-svelte.yml
+++ b/.github/workflows/build-svelte.yml
@@ -10,6 +10,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/build-svelte.yml'
       - '!**/*.md'
+      - '!packages/*/test*/**'
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/build-svelte.yml'
       - '!**/*.md'
+      - '!packages/*/test*/**'
 
 jobs:
   build-svelte-example:

--- a/.github/workflows/build-vue.yml
+++ b/.github/workflows/build-vue.yml
@@ -10,6 +10,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/build-vue.yml'
       - '!**/*.md'
+      - '!packages/*/test*/**'
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/build-vue.yml'
       - '!**/*.md'
+      - '!packages/*/test*/**'
 
 jobs:
   build-vue-example:

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -12,6 +12,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/perf-test.yml'
       - '!**/*.md'
+      - '!packages/lottie-player/tests/**'
 
 jobs:
   preview-perf-test:

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -12,6 +12,7 @@ on:
       - 'pnpm-lock.yaml'
       - '.github/workflows/playground.yml'
       - '!**/*.md'
+      - '!packages/webcanvas/test/**'
 
 jobs:
   preview-playground:


### PR DESCRIPTION
Example builds (React/Svelte/Vue) and preview deploys were running on test-only changes, even though they only consume package sources. Added negative path filters to skip them.

`build-wcanvas` and `build-player` are left as-is — they run the test suites, so test changes must still trigger them.