### PR TITLE
infra: Preserved EMSDK paths containing spaces

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -17,3 +17,4 @@
 - Yujin Lee @Ujaa
 - Yukyung Lee @nunomi0
 - Soongeon Noh @Nor-s
+- JaeHyun Hwang @hd1534

--- a/packages/lottie-player/wasm_player_setup.sh
+++ b/packages/lottie-player/wasm_player_setup.sh
@@ -2,37 +2,37 @@
 
 echo "EMSDK: $EMSDK"
 
-rm -rf build_wasm_player && sh ./wasm_player_build.sh $EMSDK/
+rm -rf build_wasm_player && sh ./wasm_player_build.sh "$EMSDK/"
 mv build_wasm_player/thorvg.wasm ./dist
 mv build_wasm_player/thorvg.js ./dist
 mv build_wasm_player/thorvg.d.ts ./dist
 
-rm -rf build_wasm_player && sh ./wasm_player_build.sh sw $EMSDK/
+rm -rf build_wasm_player && sh ./wasm_player_build.sh sw "$EMSDK/"
 mkdir -p ./dist/sw
 mv build_wasm_player/thorvg.wasm ./dist/sw
 mv build_wasm_player/thorvg.js ./dist/sw
 
-rm -rf build_wasm_player && sh ./wasm_player_build.sh gl $EMSDK/
+rm -rf build_wasm_player && sh ./wasm_player_build.sh gl "$EMSDK/"
 mkdir -p ./dist/gl
 mv build_wasm_player/thorvg.wasm ./dist/gl
 mv build_wasm_player/thorvg.js ./dist/gl
 
-rm -rf build_wasm_player && sh ./wasm_player_build.sh sw-lite $EMSDK/
+rm -rf build_wasm_player && sh ./wasm_player_build.sh sw-lite "$EMSDK/"
 mkdir -p ./dist/sw-lite
 mv build_wasm_player/thorvg.wasm ./dist/sw-lite
 mv build_wasm_player/thorvg.js ./dist/sw-lite
 
-rm -rf build_wasm_player && sh ./wasm_player_build.sh gl-lite $EMSDK/
+rm -rf build_wasm_player && sh ./wasm_player_build.sh gl-lite "$EMSDK/"
 mkdir -p ./dist/gl-lite
 mv build_wasm_player/thorvg.wasm ./dist/gl-lite
 mv build_wasm_player/thorvg.js ./dist/gl-lite
 
-rm -rf build_wasm_player && sh ./wasm_player_build.sh wg $EMSDK/
+rm -rf build_wasm_player && sh ./wasm_player_build.sh wg "$EMSDK/"
 mkdir -p ./dist/wg
 mv build_wasm_player/thorvg.wasm ./dist/wg
 mv build_wasm_player/thorvg.js ./dist/wg
 
-rm -rf build_wasm_player && sh ./wasm_player_build.sh wg-lite $EMSDK/
+rm -rf build_wasm_player && sh ./wasm_player_build.sh wg-lite "$EMSDK/"
 mkdir -p ./dist/wg-lite
 mv build_wasm_player/thorvg.wasm ./dist/wg-lite
 mv build_wasm_player/thorvg.js ./dist/wg-lite


### PR DESCRIPTION
## Summary

Quote the `EMSDK` argument passed to `wasm_player_build.sh` for all lottie-player WASM build variants.

This prevents the lottie-player build script from splitting EMSDK paths containing spaces. However, the full build still fails because EMSDK itself does not preserve its configured Node.js path as a single argument when the installation path contains spaces.

## Changes

- Preserve the complete EMSDK path for the default build
- Apply the same handling to `sw`, `gl`, `wg`, and lite variants

## Test

Verified that all lottie-player WASM build variants receive the complete EMSDK path without shell word splitting.

> [!NOTE]
> The full build may still fail due to a separate EMSDK-side path-handling issue. Until it is resolved, install EMSDK in a path without spaces.
>
> For details, see https://github.com/emscripten-core/emsdk/issues/1752.

Fixes #337