### PR TITLE
test(webcanvas): Add unit tests for uncovered Picture APIs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,4 @@ For definitions and responsibilities of each project role, see [Roles & Responsi
 - Soongeon Noh @Nor-s
 - JaeHyun Hwang @hd1534
 - DaHee Chae @chae-dahee
+- Juyon Lee  @juyonLee00

--- a/packages/webcanvas/test/picture.test.ts
+++ b/packages/webcanvas/test/picture.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { Picture } from '../src/core/Picture';
+import { getModule } from '../src/interop/module';
 import { getTVG, assertNoDoubleFree, assertGCCleanup, canForceGC } from './helpers';
 
 
-const TEST_SVG = '<svg width="100" height="100"><rect width="100" height="100" fill="red"/></svg>';
+const TEST_SVG = '<svg width="100" height="100"><rect id="target" width="100" height="100" fill="red"/></svg>';
+const TEST_RAW = new Uint8Array([255, 255, 255, 255]);
 
 describe('Picture', () => {
   it('constructor creates a picture', () => {
@@ -25,6 +27,30 @@ describe('Picture', () => {
     const picture = new TVG.Picture();
     const data = new TextEncoder().encode(TEST_SVG);
     const result = picture.load(data, { type: 'svg' });
+    expect(result).toBe(picture);
+  });
+
+  it('load RAW image data returns this', () => {
+    const TVG = getTVG();
+    const picture = new TVG.Picture();
+    const result = picture.load(TEST_RAW, { type: 'raw', width: 1, height: 1, colorSpace: TVG.ColorSpace.ARGB8888 });
+    expect(result).toBe(picture);
+    const size = picture.size();
+    expect(size.width).toBe(1);
+    expect(size.height).toBe(1);
+  });
+
+  it('load RAW image without height throws', () => {
+    const TVG = getTVG();
+    const picture = new TVG.Picture();
+    expect(() => picture.load(TEST_RAW, { type: 'raw', width: 1 })).toThrow();
+  });
+
+  it('filter returns this', () => {
+    const TVG = getTVG();
+    const picture = new TVG.Picture();
+    picture.load(TEST_RAW, { type: 'raw', width: 1, height: 1, colorSpace: TVG.ColorSpace.ARGB8888 });
+    const result = picture.filter(TVG.FilterMethod.Nearest);
     expect(result).toBe(picture);
   });
 
@@ -59,6 +85,55 @@ describe('Picture', () => {
     const picture = new TVG.Picture();
     const result = picture.paint(99999);
     expect(result).toBeNull();
+  });
+
+  it('paint returns null for non-existent name', () => {
+    const TVG = getTVG();
+    const picture = new TVG.Picture();
+    picture.load(TEST_SVG, { type: 'svg' });
+    const result = picture.paint('missing');
+    expect(result).toBeNull();
+  });
+
+  it('paint returns an SVG paint', () => {
+    const TVG = getTVG();
+    const picture = new TVG.Picture();
+    picture.load(TEST_SVG, { type: 'svg' });
+    const result = picture.paint('target');
+    expect(result).not.toBeNull();
+    expect(result?.ptr).toBeGreaterThan(0);
+  });
+
+  it('duplicate returns a new Picture', () => {
+    const TVG = getTVG();
+    const picture = new TVG.Picture();
+    picture.load(TEST_SVG, { type: 'svg' });
+    const duplicate = picture.duplicate();
+    expect(duplicate).toBeInstanceOf(Picture);
+    expect(duplicate).not.toBe(picture);
+  });
+
+  it('resolver returns this', () => {
+    const TVG = getTVG();
+    const picture = new TVG.Picture();
+    const resolver = () => false;
+    expect(picture.resolver(resolver)).toBe(picture);
+    expect(picture.resolver(null)).toBe(picture);
+  });
+
+  it('replacing a resolver removes the previous callback', () => {
+    const TVG = getTVG();
+    const module = getModule();
+    const picture = new TVG.Picture();
+    const removeFunction = vi.spyOn(module, 'removeFunction');
+    try {
+      picture.resolver(() => false);
+      picture.resolver(() => true);
+      expect(removeFunction).toHaveBeenCalledTimes(1);
+    } finally {
+      removeFunction.mockRestore();
+      picture.dispose();
+    }
   });
 
   it('dispose + GC should not double-free', () => {


### PR DESCRIPTION
`Picture.ts` had 50.00% line coverage and no focused tests for raw image loading, filter configuration, string-based paint lookup, Picture-specific duplication, or resolver lifecycle management.

Added tests covering:

- load: raw image data and missing-height validation
- filter: `Nearest` method chaining
- paint: successful and missing named lookup in accessible SVG content
- duplicate: Picture type preservation and distinct wrapper creation
- resolver: registration/removal chaining and previous callback cleanup on replacement

| Coverage | % Stmts | % Branch | % Funcs | % Lines |
|---|---:|---:|---:|---:|
| Before | 51.13 | 51.28 | 66.66 | 50.00 |
| After | 93.18 | 89.74 | 91.66 | 93.02 |