### PR TITLE
webcanvas: resolve the wasm path per preset

### DIFF
--- a/packages/webcanvas/rollup.config.js
+++ b/packages/webcanvas/rollup.config.js
@@ -17,7 +17,7 @@ const commonOutput = {
   sourcemap: true,
 };
 
-const sharedPlugins = (aliasEntries = []) => [
+const sharedPlugins = (aliasEntries, wasmPath) => [
   ...(aliasEntries.length ? [alias({ entries: aliasEntries })] : []),
   webWorkerLoader({
     targetPlatform: 'browser',
@@ -30,6 +30,7 @@ const sharedPlugins = (aliasEntries = []) => [
     values: {
       '__THORVG_VERSION__': process.env.THORVG_VERSION,
       '__PACKAGE_VERSION__': pkg.version,
+      '__WASM_PATH__': wasmPath,
     },
   }),
   commonjs({
@@ -91,7 +92,7 @@ const createWebCanvasConfig = () => {
         ...commonOutput,
       },
     ],
-    plugins: sharedPlugins(),
+    plugins: sharedPlugins([], 'dist/thorvg.wasm'),
   };
 }
 
@@ -112,7 +113,7 @@ const createThreadConfig = () => {
     ],
     plugins: sharedPlugins([
       { find: '../dist/thorvg.js', replacement: path.resolve('./dist/thread/thorvg.js') },
-    ]),
+    ], 'dist/thread/thorvg.wasm'),
   };
 }
 

--- a/packages/webcanvas/src/index.ts
+++ b/packages/webcanvas/src/index.ts
@@ -61,7 +61,7 @@ import { setThreadCount } from './interop/module';
 import ThorVGModuleFactory from '../dist/thorvg';
 
 const THORVG_VERSION = '__THORVG_VERSION__';
-const THORVG_WASM_URL = 'https://unpkg.com/@thorvg/webcanvas@__PACKAGE_VERSION__/dist/thorvg.wasm';
+const THORVG_WASM_URL = 'https://unpkg.com/@thorvg/webcanvas@__PACKAGE_VERSION__/__WASM_PATH__';
 
 /**
  * @category Initialization


### PR DESCRIPTION
THORVG_WASM_URL was a hardcoded literal,
so the thread bundle fell back to dist/thorvg.wasm whenever locateFile was omitted.