### PR TITLE
wasm: glue code size reduction

### DIFF
--- a/packages/webcanvas/wasm_wcanvas_build.sh
+++ b/packages/webcanvas/wasm_wcanvas_build.sh
@@ -33,27 +33,20 @@ EXPORTED_RUNTIME_METHODS="HEAPU8,HEAP8,HEAPU16,HEAP16,HEAPU32,HEAP32,HEAPF32,HEA
 cd ../../thorvg
 rm -rf build_wasm_wcanvas
 
-# Generate temporary cross file from wasm32.txt with WebCanvas specific modifications
-# 1. Replace EMSDK: placeholder with actual path (preserving the path structure)
-# 2. Remove -fno-exceptions from cpp_args
-# 3. Remove --closure=1 and -sEXPORTED_RUNTIME_METHODS from cpp_link_args
-# 4. Add WebCanvas specific flags: EXPORTED_FUNCTIONS, EXPORTED_RUNTIME_METHODS, exception handling, and TypeScript definitions
-# 5. For pthread builds: also add -pthread to cpp_args/cpp_link_args plus SharedArrayBuffer memory
-#    settings, and a dynamic worker pool size via PTHREAD_POOL_SIZE.
 if [ "$MODE" = "pthread" ]; then
   sed "s|EMSDK:|$EMSDK/|g" ../wasm/wasm32.txt | \
     sed "s|, '-fno-exceptions'||g" | \
     sed "s|'-fno-exceptions', ||g" | \
-    sed "s|, '--closure=1'||g" | \
     sed "s|, '-sEXPORTED_RUNTIME_METHODS=[^']*'||g" | \
+    sed "s|'-sFORCE_FILESYSTEM=1'|'-sFILESYSTEM=0'|g" | \
     sed "s|cpp_args = \[|cpp_args = ['-pthread', |g" | \
-    sed "s|'--bind'|'--bind', '-pthread', '--emit-tsd=thorvg.d.ts', '-sPTHREAD_POOL_SIZE=(typeof globalThis.__THORVG_THREAD_COUNT !== \"undefined\" ? globalThis.__THORVG_THREAD_COUNT : (typeof navigator !== \"undefined\" \&\& navigator.hardwareConcurrency ? navigator.hardwareConcurrency : 4))', '-sPTHREAD_POOL_SIZE_STRICT=0', '-sINITIAL_MEMORY=134217728', '-sEXPORTED_FUNCTIONS=${EXPORTED_FUNCTIONS}', '-sEXPORTED_RUNTIME_METHODS=${EXPORTED_RUNTIME_METHODS}', '-sDISABLE_EXCEPTION_CATCHING=0', '-sDISABLE_EXCEPTION_THROWING=0', '-sALLOW_TABLE_GROWTH=1', '-sINITIAL_TABLE=128'|g" > /tmp/.wasm_webcanvas_cross.txt
+    sed "s|'--bind'|'--bind', '-pthread', '--emit-tsd=thorvg.d.ts', '-sPTHREAD_POOL_SIZE=(typeof globalThis[\"__THORVG_THREAD_COUNT\"] !== \"undefined\" ? globalThis[\"__THORVG_THREAD_COUNT\"] : (typeof navigator !== \"undefined\" \&\& navigator.hardwareConcurrency ? navigator.hardwareConcurrency : 4))', '-sPTHREAD_POOL_SIZE_STRICT=0', '-sINITIAL_MEMORY=134217728', '-sEXPORTED_FUNCTIONS=${EXPORTED_FUNCTIONS}', '-sEXPORTED_RUNTIME_METHODS=${EXPORTED_RUNTIME_METHODS}', '-sDISABLE_EXCEPTION_CATCHING=0', '-sDISABLE_EXCEPTION_THROWING=0', '-sALLOW_TABLE_GROWTH=1', '-sINITIAL_TABLE=128'|g" > /tmp/.wasm_webcanvas_cross.txt
 else
   sed "s|EMSDK:|$EMSDK/|g" ../wasm/wasm32.txt | \
     sed "s|, '-fno-exceptions'||g" | \
     sed "s|'-fno-exceptions', ||g" | \
-    sed "s|, '--closure=1'||g" | \
     sed "s|, '-sEXPORTED_RUNTIME_METHODS=[^']*'||g" | \
+    sed "s|'-sFORCE_FILESYSTEM=1'|'-sFILESYSTEM=0'|g" | \
     sed "s|'--bind'|'--bind', '--emit-tsd=thorvg.d.ts', '-sEXPORTED_FUNCTIONS=${EXPORTED_FUNCTIONS}', '-sEXPORTED_RUNTIME_METHODS=${EXPORTED_RUNTIME_METHODS}', '-sDISABLE_EXCEPTION_CATCHING=0', '-sDISABLE_EXCEPTION_THROWING=0', '-sALLOW_TABLE_GROWTH=1', '-sINITIAL_TABLE=128'|g" > /tmp/.wasm_webcanvas_cross.txt
 fi
 
@@ -62,7 +55,7 @@ meson setup \
   -Ddefault_library=static \
   -Dstatic=true \
   -Dloaders="all,media" \
-  -Dsavers="all" \
+  -Dsavers="" \
   -Dthreads="$([ "$MODE" = "pthread" ] && echo true || echo false)" \
   -Dfile="false" \
   -Dbindings="capi" \

--- a/wasm/wasm32.txt
+++ b/wasm/wasm32.txt
@@ -14,7 +14,7 @@ exe_suffix = 'js'
 cpp_std = 'c++17'
 debug = false
 cpp_args = ['-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--use-port=emdawnwebgpu']
-cpp_link_args = ['-fno-rtti', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sDYNAMIC_EXECUTION=0', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sENVIRONMENT=web,worker', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS,FS_readFile,HEAPU8,HEAP32,HEAPU32,HEAPF32', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3', '--use-port=emdawnwebgpu']
+cpp_link_args = ['-fno-rtti', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sDYNAMIC_EXECUTION=0', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sENVIRONMENT=web,worker', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS,FS_readFile,HEAPU8,HEAP32,HEAPU32,HEAPF32', '-sMAX_WEBGL_VERSION=2', '--use-port=emdawnwebgpu']
 
 [host_machine]
 system = 'emscripten'

--- a/wasm/wasm32_gl.txt
+++ b/wasm/wasm32_gl.txt
@@ -14,7 +14,7 @@ exe_suffix = 'js'
 cpp_std = 'c++17'
 debug = false
 cpp_args = ['-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-fno-rtti', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sDYNAMIC_EXECUTION=0', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sENVIRONMENT=web,worker', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS,FS_readFile,HEAPU8,HEAP32,HEAPU32,HEAPF32', '-sMAX_WEBGL_VERSION=2', '-sFULL_ES3']
+cpp_link_args = ['-fno-rtti', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sDYNAMIC_EXECUTION=0', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sENVIRONMENT=web,worker', '-sFILESYSTEM=0', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=HEAPU8,HEAP32,HEAPU32,HEAPF32', '-sMAX_WEBGL_VERSION=2']
 
 [host_machine]
 system = 'emscripten'

--- a/wasm/wasm32_sw.txt
+++ b/wasm/wasm32_sw.txt
@@ -14,7 +14,7 @@ exe_suffix = 'js'
 cpp_std = 'c++17'
 debug = false
 cpp_args = ['-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions']
-cpp_link_args = ['-fno-rtti', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sDYNAMIC_EXECUTION=0', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sENVIRONMENT=web,worker', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS,FS_readFile,HEAPU8,HEAP32,HEAPU32,HEAPF32']
+cpp_link_args = ['-fno-rtti', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sDYNAMIC_EXECUTION=0', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sENVIRONMENT=web,worker', '-sFILESYSTEM=0', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=HEAPU8,HEAP32,HEAPU32,HEAPF32']
 
 [host_machine]
 system = 'emscripten'

--- a/wasm/wasm32_wg.txt
+++ b/wasm/wasm32_wg.txt
@@ -14,7 +14,7 @@ exe_suffix = 'js'
 cpp_std = 'c++17'
 debug = false
 cpp_args = ['-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--use-port=emdawnwebgpu']
-cpp_link_args = ['-fno-rtti', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sDYNAMIC_EXECUTION=0', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sENVIRONMENT=web,worker', '-sFORCE_FILESYSTEM=1', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=FS,FS_readFile,HEAPU8,HEAP32,HEAPU32,HEAPF32', '--use-port=emdawnwebgpu']
+cpp_link_args = ['-fno-rtti', '-Wshift-negative-value', '-flto', '-Oz', '-fno-exceptions', '--bind', '-sDYNAMIC_EXECUTION=0', '--closure=1', '-sWASM=1', '-sALLOW_MEMORY_GROWTH=1', '-sEXPORT_ES6=1', '-sENVIRONMENT=web,worker', '-sFILESYSTEM=0', '-sMODULARIZE=1', '-sEXPORTED_RUNTIME_METHODS=HEAPU8,HEAP32,HEAPU32,HEAPF32', '--use-port=emdawnwebgpu']
 
 [host_machine]
 system = 'emscripten'


### PR DESCRIPTION
- remove saver, file system from webcanvas
- apply closure compiler for webcanvas
- remove unused WASM options

### @thorvg/webcanvas

| Preset | | thorvg.js | gzip | thorvg.wasm |
|---|---|---|---|---|
| **default** | before | 193,044 | 47,068 | 906,832 |
| | after | **52,860** | **19,686** | **906,211** |
| | diff | **-140,184 (-72.6%)** | -27,382 (-58.2%) | -621 |
| **pthread** | before | 211,532 | 51,007 | 930,110 |
| | after | **60,657** | **22,829** | **929,469** |
| | diff | **-150,875 (-71.3%)** | -28,178 (-55.2%) | -641 |


### @thorvg/lottie-player

| Preset | | thorvg.js | gzip | thorvg.wasm |
|---|---|---|---|---|
| **default (`all`)** | before | 72,381 | 27,593 | 894,574 |
| | after | **70,219** | **26,711** | 894,574 |
| | diff | **-2,162 (-3.0%)** | -882 (-3.2%) | 0 |
| **gl** | before | 54,796 | 21,320 | 638,668 |
| | after | **30,721** | **12,075** | 638,668 |
| | diff | **-24,075 (-43.9%)** | -9,245 (-43.4%) | 0 |
| **sw** | before | 41,543 | 16,301 | 616,039 |
| | after | **19,673** | **8,012** | 616,039 |
| | diff | **-21,870 (-52.6%)** | -8,289 (-50.8%) | 0 |
| **wg** | before | 57,458 | 22,358 | 672,257 |
| | after | **35,902** | **13,955** | 672,257 |
| | diff | **-21,556 (-37.5%)** | -8,403 (-37.6%) | 0 |
