### PR TITLE
infra: make wasm_player_build.sh POSIX sh compatible

### DIFF
--- a/packages/lottie-player/wasm_player_build.sh
+++ b/packages/lottie-player/wasm_player_build.sh
@@ -12,22 +12,22 @@ fi
 cd ../../thorvg
 rm -rf build_wasm_player
 
-if [[ "$BACKEND" == "wg" ]]; then
+if [ "$BACKEND" = "wg" ]; then
   sed "s|EMSDK:|$EMSDK|g" ../wasm/wasm32_wg.txt > /tmp/.wasm_cross.txt
   meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="lottie, jpg, png, webp, ttf" -Dextra="lottie_exp" -Dthreads=false -Dfile="false" -Dpartial=false -Dengines="wg" --cross-file /tmp/.wasm_cross.txt build_wasm_player
-elif [[ "$BACKEND" == "sw" ]]; then
+elif [ "$BACKEND" = "sw" ]; then
   sed "s|EMSDK:|$EMSDK|g" ../wasm/wasm32_sw.txt > /tmp/.wasm_cross.txt
   meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="lottie, jpg, png, webp, ttf" -Dextra="lottie_exp" -Dthreads=false -Dpartial=false -Dfile="false" --cross-file /tmp/.wasm_cross.txt build_wasm_player
-elif [[ "$BACKEND" == "gl" ]]; then
+elif [ "$BACKEND" = "gl" ]; then
   sed "s|EMSDK:|$EMSDK|g" ../wasm/wasm32_gl.txt > /tmp/.wasm_cross.txt
   meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="lottie, jpg, png, webp, ttf" -Dextra="lottie_exp" -Dthreads=false -Dpartial=false -Dengines="gl" -Dfile="false" --cross-file /tmp/.wasm_cross.txt build_wasm_player
-elif [[ "$BACKEND" == "sw-lite" ]]; then
+elif [ "$BACKEND" = "sw-lite" ]; then
   sed "s|EMSDK:|$EMSDK|g" ../wasm/wasm32_sw.txt > /tmp/.wasm_cross.txt
   meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="lottie, png" -Dextra="" -Dthreads=false -Dpartial=false -Dfile="false" --cross-file /tmp/.wasm_cross.txt build_wasm_player
-elif [[ "$BACKEND" == "gl-lite" ]]; then
+elif [ "$BACKEND" = "gl-lite" ]; then
   sed "s|EMSDK:|$EMSDK|g" ../wasm/wasm32_gl.txt > /tmp/.wasm_cross.txt
   meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="lottie, png" -Dextra="" -Dthreads=false -Dpartial=false -Dengines="gl" -Dfile="false" --cross-file /tmp/.wasm_cross.txt build_wasm_player
-elif [[ "$BACKEND" == "wg-lite" ]]; then
+elif [ "$BACKEND" = "wg-lite" ]; then
   sed "s|EMSDK:|$EMSDK|g" ../wasm/wasm32_wg.txt > /tmp/.wasm_cross.txt
   meson setup -Db_lto=true -Ddefault_library=static -Dstatic=true -Dloaders="lottie, png" -Dextra="" -Dthreads=false -Dpartial=false -Dengines="wg" -Dfile="false" --cross-file /tmp/.wasm_cross.txt build_wasm_player
 else


### PR DESCRIPTION
## Summary

Improve the shell compatibility of `wasm_player_build.sh` so that lottie-player presets are built consistently across environments.

The preset branches use the Bash-specific `[[ ]]` syntax, while the script is invoked with `sh` from `package.json` and `wasm_player_setup.sh`. This makes the behavior depend on which shell provides `/bin/sh`.

On GitHub Actions' `ubuntu-latest` runners, where `/bin/sh` is `dash`, the conditional checks fail with `[[: not found`, causing all presets to fall back to the full build.

Reference: https://wiki.ubuntu.com/DashAsBinSh


## Changes

* Replace the six `[[ "$BACKEND" == ... ]]` tests with POSIX-compatible `[ "$BACKEND" = ... ]` tests in `packages/lottie-player/wasm_player_build.sh`.

All shell scripts in the repository pass `shellcheck -s sh` without POSIX compatibility warnings after this change.

<details>
<summary>ShellCheck results</summary>

**Before** (`main`) — 6 locations with SC3010/SC3014 warnings in `wasm_player_build.sh`:

```console id="hqyaq2"
$ git ls-files '*.sh' | xargs shellcheck -s sh -S warning -e SC2164

In packages/lottie-player/wasm_player_build.sh line 15:
if [[ "$BACKEND" == "wg" ]]; then
   ^----------------------^ SC3010 (warning): In POSIX sh, [[ ]] is undefined.
                 ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.

In packages/lottie-player/wasm_player_build.sh line 18:
elif [[ "$BACKEND" == "sw" ]]; then
     ^----------------------^ SC3010 (warning): In POSIX sh, [[ ]] is undefined.
                   ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.

In packages/lottie-player/wasm_player_build.sh line 21:
elif [[ "$BACKEND" == "gl" ]]; then
     ^----------------------^ SC3010 (warning): In POSIX sh, [[ ]] is undefined.
                   ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.

In packages/lottie-player/wasm_player_build.sh line 24:
elif [[ "$BACKEND" == "sw-lite" ]]; then
     ^---------------------------^ SC3010 (warning): In POSIX sh, [[ ]] is undefined.
                   ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.

In packages/lottie-player/wasm_player_build.sh line 27:
elif [[ "$BACKEND" == "gl-lite" ]]; then
     ^---------------------------^ SC3010 (warning): In POSIX sh, [[ ]] is undefined.
                   ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.

In packages/lottie-player/wasm_player_build.sh line 30:
elif [[ "$BACKEND" == "wg-lite" ]]; then
     ^---------------------------^ SC3010 (warning): In POSIX sh, [[ ]] is undefined.
                   ^-- SC3014 (warning): In POSIX sh, == in place of = is undefined.

For more information:
  https://www.shellcheck.net/wiki/SC3010 -- In POSIX sh, [[ ]] is undefined.
  https://www.shellcheck.net/wiki/SC3014 -- In POSIX sh, == in place of = is ...
```

**After** (this PR) — no POSIX compatibility warnings:

```console id="m5mtyf"
$ git ls-files '*.sh' | xargs shellcheck -s sh -S warning -e SC2164
```

> **Note:** `SC2164` is excluded because it warns about unchecked `cd` failures (`cd ... || exit`), which is unrelated to the POSIX compatibility issue addressed by this PR.

</details>

## Testing

Verified on `ubuntu-latest` using the Bundle Size Report on my fork: https://github.com/hd1534/thorvg.web/pull/4#issuecomment-5603530710

[Before the fix](https://github.com/hd1534/thorvg.web/pull/3#issuecomment-5528622620), every preset produced the same  size of `thorvg.wasm`.
[After the fix](https://github.com/hd1534/thorvg.web/pull/4#issuecomment-5603530710), each preset is built with its intended configuration, and the build log no longer contains `[[: not found`.

Fixes #373